### PR TITLE
Fixed time consuming line accumulation when parsing GEO files

### DIFF
--- a/R/parseGEO.R
+++ b/R/parseGEO.R
@@ -98,15 +98,18 @@ parseGeoColumns <- function(txt) {
     while(i <- i+1) {
         tmp <- try(readLines(con,1))
         if(inherits(tmp,"try-error") | length(tmp)==0) {
+            i <- i-1  # counted an extra line
             hasDataTable=FALSE
             break
         }
         txt[i] <- tmp
+        if(i==length(txt)) txt <- c(txt, character(i))  # double vector size
         if(length(grep('!\\w+_table_begin',txt[i],perl=TRUE))>0) {
             hasDataTable=TRUE
             break
         }
     }
+    txt <- txt[1:i]
     cols <- parseGeoColumns(txt)
     meta <- parseGeoMeta(txt)
     geoDataTable <- new("GEODataTable",columns=data.frame(),table=data.frame())
@@ -270,8 +273,10 @@ parseGDS <- function(fname) {
     i <- 0
     while(i <- i+1) {
         txt[i] <- suppressWarnings(readLines(con,1))
+        if(i==length(txt)) txt <- c(txt, character(i))  # double vector size
         if(length(grep('!\\w+_table_begin',txt[i],perl=TRUE))>0) break
     }
+    txt <- txt[1:i]
     cols <- parseGDSSubsets(txt)
     meta <- parseGeoMeta(txt)
     dat3 <- suppressWarnings(fastTabRead(con))
@@ -290,22 +295,21 @@ parseGDS <- function(fname) {
     hasDataTable=FALSE
     while(i <- i+1) {
         tmp <- try(readLines(con,1))
-        if(inherits(tmp,"try-error") | length(tmp)==0 ) {
+        if(inherits(tmp,"try-error")
+           || length(tmp)==0
+           || (!is.null(n) && i==n)) {
+            i <- i-1  # counted an extra line
             hasDataTable=FALSE
             break
         }
-        if(!is.null(n)) {
-            if(i==n) {
-                hasDataTable=FALSE
-                break
-            }
-        }
         txt[i] <- tmp
+        if(i==length(txt)) txt <- c(txt, character(i))  # double vector size
         if(length(grep('!\\w+_table_begin',txt[i],perl=TRUE))>0) {
             hasDataTable=TRUE
             break
         }
     }
+    txt <- txt[1:i]
     cols <- parseGeoColumns(txt)
     meta <- parseGeoMeta(txt)
     geoDataTable <- new("GEODataTable",columns=data.frame(),table=data.frame())


### PR DESCRIPTION
Hello again, Mr Davis.

I've found a good way to fix that annoying problem without touching the connections after reading [this article](http://www.win-vector.com/blog/2015/07/efficient-accumulation-in-r/). It seems that R's behaviour is nearly impredictable sometimes! But it can be done. I used `txt` as a [doubling array](https://en.wikipedia.org/wiki/Dynamic_array) to accumulate the lines, so R could do the `txt[i] <- tmp` assignments as in place operations.

This time, I got no errors in the unit test. The performance was greatly improved –for example, parsing GPL570 SOFT takes just 20% of the original time! You can see the big difference also in the unit test timing.

Before:

    R > system.time(BiocGenerics:::testPackage("GEOquery"))
    [...]
    GEOquery RUnit Tests - 14 test functions, 0 errors, 0 failures
         user    system   elapsed
      122.741     0.564   158.452

After:

    R > system.time(BiocGenerics:::testPackage("GEOquery"))
    [...]
    GEOquery RUnit Tests - 14 test functions, 0 errors, 0 failures
         user    system   elapsed
       54.566     1.251    90.679