### PR TITLE
GPL objects caching system

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,6 @@
 .onLoad <- function(lib,pkg) {
   packageStartupMessage("Setting options('download.file.method.GEOquery'='auto')")
   options('download.file.method.GEOquery'='auto')
+  packageStartupMessage("Setting options('GEOquery.inmemory.gpl'=FALSE)")
+  options('GEOquery.inmemory.gpl'=FALSE)
 }


### PR DESCRIPTION
Following what we discussed last week, this is the first draft of the _in memory_ caching system for GPL objects. I made it disabled by default, so the current behaviour is unmodified. The user will need to  activate this mechanism modifying `options` **after** loading the package, as follows:

```R
R > library(GEOquery)
[...]
Setting options('download.file.method.GEOquery'='auto')
Setting options('GEOquery.inmemory.gpl'=FALSE)

R > gpl96_1 <- getGEO('GPL96')
File stored at:                                     # The GPL SOFT file is downloaded
/tmp/Rtmp34ADw7/GPL96.soft                          # and cached locally on disk.

R > gpl96_2 <- getGEO('GPL96')
Using locally cached version of GPL96 found here:   # Then, it is reparsed whenever
/tmp/Rtmp34ADw7/GPL96.soft                          # it is required (directly or not).

R > identical(gpl96_1, gpl96_2)
[1] TRUE
R > data.table::address(gpl96_1)
[1] "0x597e5b8"  # --------------\
R > data.table::address(gpl96_2)  #----> different memory adresses
[1] "0x87989f0"  # --------------/

R > options('GEOquery.inmemory.gpl'=TRUE)           # We then activate the caching.

R > gpl96_1 <- getGEO('GPL96')
Using locally cached version of GPL96 found here:   # On the first call, the object
/tmp/Rtmp34ADw7/GPL96.soft                          # is cached in memory.

R > gpl96_2 <- getGEO('GPL96')
Using locally cached version of GPL96 found here:   # From the second on, it is recovered
/tmp/Rtmp34ADw7/GPL96.soft                          # and the call returns instantaneously!
Using GPL object found in memory from locally cached version.

R > identical(gpl96_1, gpl96_2)
[1] TRUE
R > data.table::address(gpl96_1)
[1] "0x59ab2a8"  # --------------\
R > data.table::address(gpl96_2)  #----> identical memory adresses too
[1] "0x59ab2a8"  # --------------/
```