### PR TITLE
fixed problem parsing empty "characteristics" key:value fields.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: GEOquery
 Type: Package
 Title: Get data from NCBI Gene Expression Omnibus (GEO)
-Version: 2.45.2
-Date: 2017-09-25
+Version: 2.45.3
+Date: 2017-11-07
 Author: Sean Davis <sdavis2@mail.nih.gov>
 Maintainer: Sean Davis <sdavis2@mail.nih.gov>
 BugReports: https://github.com/seandavi/GEOquery/issues/new


### PR DESCRIPTION
The new code for parsing the 'characteristics_ch1' fields fails if the field is present, but doesn't actually contain key:value pairs.  For example [GSE5350-GPL2507_series_matrix.txt.gz](ftp://ftp.ncbi.nlm.nih.gov/geo/series/GSE5nnn/GSE5350/matrix/GSE5350-GPL2507_series_matrix.txt.gz) is has two such fields, but they are either `NA` or empty strings.  These are all then filtered out, and the call to `tidyr::spread()` throws an unhelpful error when passed an empty `data_frame`.

This fix tries to catch such examples and then simply skip the efforts to split into keys and values.