### PR TITLE
Added: `parseCharacteristics` flag

### DIFF
--- a/R/getGEO.R
+++ b/R/getGEO.R
@@ -84,6 +84,9 @@
 #' featureData using Bioconductor tools rather than relying on information
 #' provided through NCBI GEO.  Download times can also be greatly reduced by
 #' specifying FALSE.
+#' @param parseCharacteristics A boolean defaulting to TRUE as to whether or not
+#' to parse the characteristics information (if available) for a GSE Matrix file.
+#' Set this to FALSE if you experience trouble while parsing the characteristics.
 #' @return An object of the appropriate class (GDS, GPL, GSM, or GSE) is
 #' returned.  If the GSEMatrix option is used, then a list of ExpressionSet
 #' objects is returned, one for each SeriesMatrix file associated with the GSE
@@ -113,7 +116,8 @@ getGEO <- function(GEO=NULL,
                    destdir=tempdir(),
                    GSElimits=NULL,GSEMatrix=TRUE,
                    AnnotGPL=FALSE,
-                   getGPL=TRUE) {
+                   getGPL=TRUE,
+                   parseCharacteristics=TRUE) {
   con <- NULL
   if(!is.null(GSElimits)) {
     if(length(GSElimits)!=2) {
@@ -127,7 +131,7 @@ getGEO <- function(GEO=NULL,
     GEO <- toupper(GEO)
     geotype <- toupper(substr(GEO,1,3))
     if(GSEMatrix & geotype=='GSE') {
-      return(getAndParseGSEMatrices(GEO,destdir,AnnotGPL=AnnotGPL,getGPL=getGPL))
+      return(getAndParseGSEMatrices(GEO,destdir,AnnotGPL=AnnotGPL,getGPL=getGPL,parseCharacteristics=parseCharacteristics))
     }
     filename <- getGEOfile(GEO,destdir=destdir,AnnotGPL=AnnotGPL)
   }      

--- a/R/parseGEO.R
+++ b/R/parseGEO.R
@@ -426,7 +426,7 @@ txtGrab <- function(regex,x) {
 ### Function wrapper to get and parse ALL
 ### the GSEMatrix files associated with a GSE
 ### into a list of ExpressionSets
-getAndParseGSEMatrices <- function(GEO,destdir,AnnotGPL,getGPL=TRUE) {
+getAndParseGSEMatrices <- function(GEO,destdir,AnnotGPL,getGPL=TRUE,parseCharacteristics=TRUE) {
     GEO <- toupper(GEO)
     ## This stuff functions to get the listing of available files
     ## for a given GSE given that there may be many GSEMatrix
@@ -462,7 +462,7 @@ getAndParseGSEMatrices <- function(GEO,destdir,AnnotGPL,getGPL=TRUE) {
 #' @param AnnotGPL 
 #' @param destdir 
 #' @param getGPL 
-parseGSEMatrix <- function(fname,AnnotGPL=FALSE,destdir=tempdir(),getGPL=TRUE) {
+parseGSEMatrix <- function(fname,AnnotGPL=FALSE,destdir=tempdir(),getGPL=TRUE,parseCharacteristics=TRUE) {
     dat <- read_lines(fname)
     ## get the number of !Series and !Sample lines
     #nseries <- sum(grepl("^!Series_", dat))
@@ -484,7 +484,7 @@ parseGSEMatrix <- function(fname,AnnotGPL=FALSE,destdir=tempdir(),getGPL=TRUE) {
     ## annotation. If that is the case, this simply
     ## cleans those up and transforms the keys to column
     ## names and the values to column values.
-    if(length(grep('characteristics_ch',colnames(sampledat)))>0) {
+    if(length(grep('characteristics_ch',colnames(sampledat)))>0 && parseCharacteristics) {
         pd = sampledat %>%
             dplyr::select(dplyr::contains('characteristics_ch')) %>%
             dplyr::mutate(accession = rownames(.)) %>%


### PR DESCRIPTION
The `parseCharacteristics` flag allows us to disable the parsing of characteristics from Matrix files, as this is prone to errors.