### PR TITLE
Do not freeze on empty files

### DIFF
--- a/R/parseGEO.R
+++ b/R/parseGEO.R
@@ -227,6 +227,7 @@ parseGSE <- function(fname,GSElimits=NULL) {
 findFirstEntity <- function(con) {
     while(TRUE) {
         line <- suppressWarnings(readLines(con,100))
+        if (length(line) == 0) return(0)
         entity.line <- grep('^\\^(DATASET|SAMPLE|SERIES|PLATFORM|ANNOTATION)',
                             line,ignore.case=TRUE,value=TRUE,perl=TRUE)
         entity.line <- gsub('annotation','platform',entity.line,ignore.case=TRUE)

--- a/tests/testthat/test_GSE.R
+++ b/tests/testthat/test_GSE.R
@@ -91,3 +91,7 @@ test_that("GSE populates experimentData as much as possible", {
   expect_equivalent(ei[5], "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE27712") #url
   expect_equivalent(abstract(ed), "This SuperSeries is composed of the SubSeries listed below.")
 })
+
+test_that("Empty files produces an error", {
+  expect_error(getGEO(filename = system.file('extdata/GPLbroken.soft.gz', package="GEOquery")))
+})


### PR DESCRIPTION
Yesterday i ran into an issue that when somehow downloading GSE\GPL failed and crashed ungracefully then a created empty file will make next request freeze in a infinite loop 