### PR TITLE
fix a test that failed with strict boolean check-lengths

### DIFF
--- a/R/parseGEO.R
+++ b/R/parseGEO.R
@@ -546,7 +546,7 @@ parseGSEMatrix <- function(fname,AnnotGPL=FALSE,destdir=tempdir(),getGPL=TRUE,pa
             # (attributes).
             mutate_all(as.character) %>%
             tidyr::gather(characteristics, kvpair, -accession) %>%
-            dplyr::filter(grepl(':',kvpair) && !is.na(kvpair))
+            dplyr::filter(grepl(':',kvpair) & !is.na(kvpair))
         # Thx to Mike Smith (@grimbough) for this code
         # sometimes the "characteristics_ch1" fields are empty and contain no 
         # key:value pairs. spread() will fail when called on an


### PR DESCRIPTION
The Travis CI for GEOquery was failing (Commit: 9776a8b) with an error message
indicating that two length-12 boolean vectors were being compared with `&&`.

R CMD check for R-3.6 & 3.7 are stricter than R-3.5 wrt Boolean comparisons (the behaviour of R CMD check for the newer versions can be replicated by setting Sys.setenv("_R_CHECK_LENGTH_1_LOGIC2_" = TRUE)).

An `&&` operator was replaced with the vectorised form `&`.