### PR TITLE
Downloading gzipped soft files

### DIFF
--- a/R/getGEOfile.R
+++ b/R/getGEOfile.R
@@ -86,10 +86,11 @@ getGEOfile <- function(GEO,destdir=tempdir(),AnnotGPL=FALSE,
       } 
       gseurl <- "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi"
       myurl <- paste(gseurl,'?targ=self&acc=',GEO,'&form=text&view=',amount,sep='')
-      destfile <- file.path(destdir,paste(GEO,'.soft',sep=""))
+      destfile <- file.path(destdir,paste(GEO,'.soft.gz',sep=""))
       mode <- 'w'
       if(!file.exists(destfile)) {
-        download.file(myurl,destfile,mode=mode,quiet=TRUE,method=getOption('download.file.method.GEOquery'))
+        download.file(myurl,destfile,mode=mode,quiet=TRUE,method=getOption('download.file.method.GEOquery'),
+                      headers = c("accept-encoding"="gzip"))
         message('File stored at: ')
         message(destfile)
       } else {


### PR DESCRIPTION
Adding 'accept-encoding: gzip' header makes downloaded soft files to be in gzip format.

Fixes #91 

