### PR TITLE
Added check to detect/remove failed downloads

### DIFF
--- a/R/getGEOSuppFiles.R
+++ b/R/getGEOSuppFiles.R
@@ -83,11 +83,29 @@ getGEOSuppFiles <- function(GEO, makeDirectory = TRUE,
   }
   if(fetch_files) {
       for(i in fnames) {
-          download.file(paste(file.path(url,i),'tool=geoquery',sep="?"),
-                        destfile=file.path(storedir,i),
+        destfile <- file.path(storedir,i)
+
+        result <- tryCatch({
+          res <- download.file(paste(file.path(url,i),'tool=geoquery',sep="?"),
+                        destfile=destfile,
                         mode='wb',
                         method=getOption('download.file.method.GEOquery'))
-          fileinfo[[file.path(storedir,i)]] <- file.info(file.path(storedir,i))
+          ## download.file returns a "0" on success
+          res == 0
+        },
+        error = function(e) return(FALSE),
+        warning = function(w) return(FALSE))
+
+        ## if the download failed, remove the corrupted file and report the error
+        if (!result) {
+          if (file.exists(destfile)) {
+            file.remove(destfile)
+          }
+          stop(sprintf('Failed to download %s!', destfile))
+        }
+        ###
+        ###
+          fileinfo[[destfile]] <- file.info(destfile)
       }
       return(do.call(rbind,fileinfo))
   } else {

--- a/R/getGEOfile.R
+++ b/R/getGEOfile.R
@@ -71,7 +71,7 @@ getGEOfile <- function(GEO,destdir=tempdir(),AnnotGPL=FALSE,
         # use it, else move on to submitter GPL
         res=try({
           if(!file.exists(destfile)) {
-            download.file(myurl,destfile,mode=mode,quiet=TRUE,method=getOption('download.file.method.GEOquery'))
+            downloadFile(myurl, destfile, mode)
             message('File stored at: ')
             message(destfile)
           } else {
@@ -89,7 +89,7 @@ getGEOfile <- function(GEO,destdir=tempdir(),AnnotGPL=FALSE,
       destfile <- file.path(destdir,paste(GEO,'.soft',sep=""))
       mode <- 'w'
       if(!file.exists(destfile)) {
-        download.file(myurl,destfile,mode=mode,quiet=TRUE,method=getOption('download.file.method.GEOquery'))
+        downloadFile(myurl, destfile, mode)
         message('File stored at: ')
         message(destfile)
       } else {
@@ -104,7 +104,7 @@ getGEOfile <- function(GEO,destdir=tempdir(),AnnotGPL=FALSE,
       mode <- 'w'
     }
     if(!file.exists(destfile)) {
-      download.file(myurl,destfile,mode=mode,quiet=TRUE,method=getOption('download.file.method.GEOquery'))
+      downloadFile(myurl, destfile, mode)
       message('File stored at: ')
       message(destfile)
     } else {
@@ -177,4 +177,27 @@ gunzip <- function(filename, destname=gsub("[.]gz$", "", filename), overwrite=FA
   }
     
   invisible(nbytes);
+}
+
+#'
+#' Wrapper for download.file() that removes files upon download failure 
+#'
+downloadFile <- function(url, destfile, mode, quiet=TRUE) {
+    result <- tryCatch({
+      res <- download.file(url, destfile=destfile, mode=mode, quiet=quiet,
+                           method=getOption('download.file.method.GEOquery'))
+      ## download.file returns a "0" on success
+      res == 0
+    },
+    error = function(e) return(FALSE),
+    warning = function(w) return(FALSE))
+
+    ## if the download failed, remove the corrupted file and report the error
+    if (!result) {
+      if (file.exists(destfile)) {
+        file.remove(destfile)
+      }
+      stop(sprintf('Failed to download %s!', destfile))
+    }
+    return(0)
 }

--- a/R/parseGEO.R
+++ b/R/parseGEO.R
@@ -457,9 +457,23 @@ getAndParseGSEMatrices <- function(GEO,destdir,AnnotGPL,getGPL=TRUE,parseCharact
         if(file.exists(destfile)) {
             message(sprintf('Using locally cached version: %s',destfile))
         } else {
-            download.file(sprintf('https://ftp.ncbi.nlm.nih.gov/geo/series/%s/%s/matrix/%s',
-                                  stub,GEO,b[i]),destfile=destfile,mode='wb',
-                          method=getOption('download.file.method.GEOquery'))
+            result <- tryCatch({
+              res <- download.file(sprintf('https://ftp.ncbi.nlm.nih.gov/geo/series/%s/%s/matrix/%s',
+                                   stub,GEO,b[i]),destfile=destfile,mode='wb',
+                            method=getOption('download.file.method.GEOquery'))
+              ## download.file returns a "0" on success
+              res == 0
+            },
+            error = function(e) return(FALSE),
+            warning = function(w) return(FALSE))
+
+            ## if the download failed, remove the corrupted file and report the error
+            if (!result) {
+              if (file.exists(destfile)) {
+                file.remove(destfile)
+                stop(sprintf('Failed to download %s!', destfile))
+              }
+            }
         }
         ret[[b[i]]] <- parseGSEMatrix(destfile,destdir=destdir,AnnotGPL=AnnotGPL,getGPL=getGPL)$eset
     }


### PR DESCRIPTION
Wrapped `download.file()` calls in try/catch blocks so that failed/incomplete file downloads can be removed to avoid having subsequent calls to `getGEO()` use the broken files.

Fixes #112.