### PR TITLE
fix table parser when table is empty

### DIFF
--- a/R/parseGEO.R
+++ b/R/parseGEO.R
@@ -298,11 +298,18 @@ fastTabRead <- function(con,sep="\t",header=TRUE,sampleRows=100,
     tbl_begin=length(txt)
     has_table = FALSE
   }
+  
+  if (has_table) {
+    metadata_rows <- seq_len(tbl_begin-2)
+  } else {
+    metadata_rows <- seq_along(txt) 
+  }
+  
+  
   # Find last line of the table
   # Edge case is that the record does not have a table end 
   # line, in which case we use all lines
   tbl_end = grep('!\\w+_table_end',txt,perl=TRUE)
-  metadata_rows = 1:(tbl_begin-2)
   if(length(tbl_end)==0) {
     tbl_end = length(txt)
   } else {


### PR DESCRIPTION
`metadata_rows` were incorrectly set, should be all lines when there is no table

Here is an example of the error it fixes:
```{r}
f <- getGEOfile("GPL17021")
tail(readLines(f)) # the last series_id entry is GSE186800
gpl <- parseGPL(f)

tail(gpl@header$series_id) # the last series_id is NOT GSE186800
print(gpl@header$data_row_count) # NULL, should be 0
file.remove(f)

f <- getGEOfile("GPL17021", amount = "data")
gpld <- parseGPL(f) # error
file.remove(f)
```