### PR TITLE
Added R.utils to imports 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ Imports: httr,
     data.table,
     tidyr,
     magrittr,
+    R.utils,
     limma
 Suggests: knitr, rmarkdown, BiocGenerics,
     testthat, covr, markdown


### PR DESCRIPTION
Needed by data.table::fread to handle compresed files, or else, calls to `getGEO()` will result in:

```
Error in data.table::fread(fname, sep = "") :
  To read gz and bz2 files directly, fread() requires 'R.utils' package which cannot
 be found. Please install 'R.utils' using 'install.packages('R.utils')'.
Calls: getGEO -> getAndParseGSEMatrices -> parseGSEMatrix -> <Anonymous>
```