### PR TITLE
Make `timeout` configurable in `downloadFile()`

### DIFF
--- a/R/getGEOfile.R
+++ b/R/getGEOfile.R
@@ -182,7 +182,7 @@ gunzip <- function(filename, destname = gsub("[.]gz$", "", filename), overwrite 
 downloadFile <- function(url, destfile, mode, quiet = TRUE) {
     h <- curl::new_handle()
     curl::handle_setheaders(h, `accept-encoding` = "gzip")
-    timeout_seconds = 120
+    timeout_seconds <- max(getOption("timeout"), 120)
     curl::handle_setopt(h, timeout_ms = timeout_seconds * 1000)
     result = tryCatch({
         curl::curl_download(url, destfile, mode = mode, quiet = quiet, handle = h)


### PR DESCRIPTION
The default 120 seconds may not be enough, e.g., #138 and https://d.cosx.org/d/423763

> Timeout was reached: [] Operation timed out after 120000 milliseconds with 47824896 out of 156738322 bytes received...

After this PR, they can increase the value by, e.g., `options(timeout = 600)` (10 mins).

`options('timeout')` defaults to 60 in base R, so this PR won't change your default (`max(60, 120) == 120`).