### PR TITLE
Add contributor scaffolding and changelog conventions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@ Dockerfile
 ^adr$
 ^CLAUDE\.md$
 ^ROADMAP\.md$
+^CONTRIBUTING\.md$

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repo — auto-requested for review on PRs.
+* @seandavi

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Report incorrect behavior, an error, or a parsing failure
+labels: ["bug", "needs-repro"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. The single most useful thing you can provide is a
+        **GEO accession** and a **minimal reproducible example** — most GEOquery
+        bugs are specific to how one record is formatted on NCBI.
+  - type: input
+    id: accession
+    attributes:
+      label: GEO accession(s)
+      description: The GSE / GSM / GPL / GDS accession(s) that trigger the problem.
+      placeholder: e.g. GSE23397
+    validations:
+      required: true
+  - type: textarea
+    id: reprex
+    attributes:
+      label: Reproducible example
+      description: Minimal R code that reproduces the issue. Please use a reprex if you can.
+      render: r
+      placeholder: |
+        library(GEOquery)
+        gse <- getGEO("GSE23397", GSEMatrix = TRUE)
+    validations:
+      required: true
+  - type: textarea
+    id: observed
+    attributes:
+      label: What happened?
+      description: The full error message, warning, or wrong output. Paste the verbatim console output.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: false
+  - type: textarea
+    id: sessioninfo
+    attributes:
+      label: Session info
+      description: Output of `sessionInfo()` (or `sessioninfo::session_info()`). Includes your GEOquery and R versions.
+      render: text
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Bioconductor support site
+    url: https://support.bioconductor.org/
+    about: Usage questions ("how do I ...?") are best asked here, tagged `geoquery`. You'll reach a wider audience and a searchable archive.
+  - name: GEO (NCBI) data questions
+    url: https://www.ncbi.nlm.nih.gov/geo/info/
+    about: Questions about GEO records themselves (not the R package) should go to NCBI GEO.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest new functionality or an enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the use case or limitation you are running into.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like GEOquery to do? An example API call is helpful.
+      render: r
+    validations:
+      required: false
+  - type: input
+    id: accession
+    attributes:
+      label: Example accession (if relevant)
+      description: A GEO accession that exercises the requested capability.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!--
+Thanks for contributing to GEOquery! Please complete the checklist below.
+See CONTRIBUTING.md for the full development workflow and conventions.
+-->
+
+## What does this PR do?
+
+<!-- One or two sentences. Link the issue it closes, e.g. "Fixes #123". -->
+
+Fixes #
+
+## Checklist
+
+- [ ] **NEWS** — added a user-facing entry to `NEWS.md` under `# GEOquery (development version)`, ending with the PR link, e.g. `* `getGEO()` now ... (#NNN).` (Skip only for CI/internal-only changes.)
+- [ ] **Tests** — added or updated tests covering the change. Network-dependent tests are gated (`skip_if_offline()` / fixtures) where applicable.
+- [ ] **Docs** — ran `devtools::document()`; `man/` and `NAMESPACE` are regenerated and committed (do not hand-edit).
+- [ ] **Version** — bumped `Version:` (`z`) and `Date:` in `DESCRIPTION` (Bioconductor convention; skip for build-excluded changes).
+- [ ] **Checks** — `R CMD check` and `BiocCheck::BiocCheck()` pass locally (or the required CI legs are green).
+- [ ] **ADR** — for a non-trivial architectural decision, added an `adr/NNNN-*.md` (see `adr/template.md`).
+
+## Notes for reviewers
+
+<!-- Anything reviewers should focus on, trade-offs, or follow-ups. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing to GEOquery
+
+Thanks for contributing. This guide covers the development workflow, the
+changelog convention, and the checks a pull request must pass. GEOquery is a
+[Bioconductor](https://bioconductor.org) package; `devel` is the working branch.
+
+## Issues vs. pull requests
+
+Not every change needs an issue — file one where it helps users and
+contributors, not as ceremony.
+
+- **Bug, feature, or behavior change → open an issue first** (or link an
+  existing one), then reference it from the PR with `Fixes #123`. These are
+  user-facing, so they also get a `NEWS.md` bullet that links both the issue
+  and the PR. For bugs, include a **GEO accession + reproducible example +
+  `sessionInfo()`** (the bug issue form prompts for these).
+- **Chore, CI, docs, or refactor → a pull request alone is fine.** No issue
+  needed; use a `chore:` / `ci:` / `docs:` / `refactor:` commit prefix.
+
+Planned work is tracked on the [`3.0` milestone](https://github.com/seandavi/GEOquery/milestones);
+see `ROADMAP.md` for the broader plan.
+
+## Development workflow
+
+1. Branch off `devel` (e.g. `git switch -c fix/issue-123`).
+2. Make the change. Keep PRs focused — one logical change per PR.
+3. Reload and test locally:
+   ```r
+   devtools::load_all(".")
+   devtools::test()                 # or devtools::test(filter = "GSE") for one file
+   ```
+4. Regenerate docs if you touched roxygen:
+   ```r
+   devtools::document()             # updates man/ and NAMESPACE — never hand-edit these
+   ```
+5. Update `NEWS.md` (see below) and bump the version (see below).
+6. Open a pull request against `devel`. The PR template's checklist is the
+   contract; CI runs `R CMD check` across a platform matrix.
+7. Merge when the required checks are green. (`devel` is branch-protected; the
+   required legs are the Ubuntu and macOS `R CMD check` jobs.)
+
+## NEWS / changelog convention
+
+We follow the [tidyverse NEWS style](https://style.tidyverse.org/news.html).
+Every user-facing change gets one bullet in `NEWS.md` under the top
+`# GEOquery (development version)` header (this header is renamed to the release
+version at release time).
+
+Rules:
+
+- Write a **complete sentence** describing the change from the **user's**
+  perspective. Put function/argument names in backticks.
+- **End every bullet with the PR link**, and credit the contributor:
+  ```markdown
+  * `getGEO(parseCharacteristics = FALSE)` no longer parses characteristics;
+    the flag is now threaded through `parseGSEMatrix()` (#166, @reporter).
+  ```
+- Group bullets under `## Breaking changes`, `## New features`, or
+  `## Bug fixes` only once there are enough to warrant it; otherwise a flat list
+  is fine. Most recent entries at the top.
+- The `#NNN` and `@user` references autolink in the pkgdown changelog and on
+  GitHub (the repo URL comes from `DESCRIPTION`).
+- **Skip NEWS** for CI-only or internal-only changes (nothing user-visible).
+
+## Versioning
+
+Bump `Version:` and `Date:` in `DESCRIPTION` on every code PR, following the
+Bioconductor convention (increment the `z` in `x.y.z` during the `devel` cycle).
+Build-excluded changes (anything matched by `.Rbuildignore`, e.g. `.github/`,
+`CONTRIBUTING.md`, `ROADMAP.md`) do not require a version bump.
+
+## Checks before merge
+
+- `R CMD check` — no errors or warnings.
+- `BiocCheck::BiocCheck()` — Bioconductor-specific requirements.
+- `lintr::lint_package()` — style (config in `.lintr`).
+
+## Architecture Decision Records
+
+Non-trivial architectural decisions are recorded as ADRs in `adr/` (see
+`adr/template.md` and `CLAUDE.md`). If your PR changes a parse path, a return
+type, a dependency, or a notable trade-off, add a numbered ADR.
+
+## Reporting bugs
+
+Open an issue with a **GEO accession**, a **minimal reproducible example**, and
+`sessionInfo()`. Most GEOquery bugs are specific to how one record is formatted
+on NCBI, so the accession is essential for reproduction.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,3 +2,5 @@ url: http://seandavi.github.io/GEOquery/
 template:
   bootstrap: 5
   light-switch: true
+development:
+  mode: auto


### PR DESCRIPTION
Establishes a professional contribution + changelog workflow.

**NEWS / changelog** — adopts the [tidyverse style](https://style.tidyverse.org/news.html): user-facing sentences under `# GEOquery (development version)`, each bullet ending with the PR link and crediting the contributor, e.g. `* `getGEO()` now ... (#166, @reporter).` These `#NNN` / `@user` refs autolink in the pkgdown changelog and on GitHub. The historical NEWS.md (and the 2.77/2.99 version reconciliation) is intentionally left for the 3.0 batch.

**Added**
- `.github/PULL_REQUEST_TEMPLATE.md` — checklist: NEWS, tests, `document()`, version bump, BiocCheck, ADR.
- `.github/ISSUE_TEMPLATE/` — bug form (requires accession + reprex + `sessionInfo()`, labels `bug`/`needs-repro` to feed the planned repro harness), feature form, and `config.yml` routing usage questions to the Bioconductor support site.
- `CONTRIBUTING.md` — dev loop, NEWS convention, version rule, required checks, ADR pointer.
- `.github/CODEOWNERS` — auto review-request.

**pkgdown** — `development: mode: auto` so the dev-version banner renders.

No package version bump: every change is build-excluded (`.github/`, `CONTRIBUTING.md`, `_pkgdown.yml`); `CONTRIBUTING.md` added to `.Rbuildignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)