### PR TITLE
CI: fix windows-latest by not forcing DropletUtils in single-cell vignette

### DIFF
--- a/vignettes/single-cell.qmd
+++ b/vignettes/single-cell.qmd
@@ -14,7 +14,7 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r message=FALSE, warning=FALSE, eval=TRUE}
+```{r message=FALSE, warning=FALSE, eval=FALSE}
 library(GEOquery)
 library(SingleCellExperiment)
 library(DropletUtils)


### PR DESCRIPTION
**Root cause of the persistent `windows-latest` R-CMD-check failure** (confirmed from fresh logs on the #164 run): the single-cell vignette is an all-`eval: false` skeleton, but its first chunk overrode that with `eval=TRUE` to `library(SingleCellExperiment)` + `library(DropletUtils)`. DropletUtils' compiled dependency chain (beachmat, etc.) installs on macOS/Linux but fails on the Windows runner, so `quarto_render()` failed and broke `R CMD check` on windows only. The other 4 matrix legs were already green.

**Fix:** set that chunk to `eval=FALSE`, matching the rest of the skeleton. Reverted to evaluate when the single-cell vignette is actually completed (roadmap SC items) and the heavy-dependency story is settled (planned ADR-0004 on single-cell architecture).

Once this is green, all five matrix legs pass and `devel` has a fully-green required + non-required check set — making "merge when green" trustworthy.

No version bump (build-hygiene; version lineage reconciled in the 3.0 batch). No NEWS entry (not user-facing; NEWS deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)