### PR TITLE
test: synthetic offline fixtures for parseGSEMatrix (Tier 1 prototype)

### DIFF
--- a/tests/testthat/test_parse_synthetic.R
+++ b/tests/testthat/test_parse_synthetic.R
@@ -1,0 +1,70 @@
+# Offline, synthetic-fixture tests for the series-matrix parser.
+#
+# These exercise the parsing logic without any network access or stored data
+# files: the "fixture" is a few KB of crafted text written to a tempfile (see
+# issue #169 for the testing strategy). Keep fixtures minimal.
+
+# Build a minimal GEO series-matrix file and return its path. The file has
+# `n_features` probes x 2 samples, two characteristics_ch1 key:value rows, and
+# the table delimited by the !series_matrix_table_begin/_end markers.
+make_fake_series_matrix <- function(n_features = 2) {
+    probes <- sprintf("probe_%d", seq_len(n_features))
+    header <- c(
+        "!Series_title\tGEOquery synthetic test series",
+        "!Series_geo_accession\tGSE000001",
+        "!Series_summary\tsynthetic fixture for offline parser tests",
+        "!Sample_title\tsampleA\tsampleB",
+        "!Sample_geo_accession\tGSM000001\tGSM000002",
+        "!Sample_characteristics_ch1\ttissue: liver\ttissue: brain",
+        "!Sample_characteristics_ch1\tagent: none\tagent: drug",
+        "!Sample_platform_id\tGPL000001\tGPL000001",
+        "!series_matrix_table_begin",
+        "\"ID_REF\"\t\"GSM000001\"\t\"GSM000002\""
+    )
+    rows <- vapply(seq_len(n_features), function(i) {
+        sprintf("\"%s\"\t%f\t%f", probes[i], i + 0.5, i + 10.5)
+    }, character(1))
+    txt <- c(header, rows, "!series_matrix_table_end")
+    f <- tempfile(fileext = ".txt")
+    writeLines(txt, f)
+    f
+}
+
+test_that("parseGSEMatrix parses a synthetic series matrix offline (getGPL = FALSE)", {
+    f <- make_fake_series_matrix(n_features = 3)
+    res <- GEOquery:::parseGSEMatrix(f, getGPL = FALSE)
+    eset <- res$eset
+
+    expect_s4_class(eset, "ExpressionSet")
+    expect_equal(nrow(Biobase::exprs(eset)), 3L)
+    expect_equal(ncol(Biobase::exprs(eset)), 2L)
+    expect_equal(Biobase::sampleNames(eset), c("GSM000001", "GSM000002"))
+    # feature names come from featureData (probes); assert value by position
+    # because exprs() rownames are dropped on the getGPL = FALSE path (a known
+    # inconsistency in parseGSEMatrix -- see #173).
+    expect_equal(Biobase::featureNames(eset), c("probe_1", "probe_2", "probe_3"))
+    expect_equal(unname(Biobase::exprs(eset)[1, 1]), 1.5)
+})
+
+test_that("parseCharacteristics = TRUE unpacks characteristics_ch1 into pData columns", {
+    f <- make_fake_series_matrix()
+    eset <- GEOquery:::parseGSEMatrix(f, getGPL = FALSE, parseCharacteristics = TRUE)$eset
+    pd <- Biobase::pData(eset)
+
+    expect_true("tissue:ch1" %in% colnames(pd))
+    expect_true("agent:ch1" %in% colnames(pd))
+    expect_equal(trimws(as.character(pd["GSM000001", "tissue:ch1"])), "liver")
+    expect_equal(trimws(as.character(pd["GSM000002", "agent:ch1"])), "drug")
+})
+
+test_that("parseCharacteristics = FALSE leaves characteristics unparsed (regression for #60)", {
+    f <- make_fake_series_matrix()
+    eset <- GEOquery:::parseGSEMatrix(f, getGPL = FALSE, parseCharacteristics = FALSE)$eset
+    cols <- colnames(Biobase::pData(eset))
+
+    # the split key:value columns must NOT be created ...
+    expect_false("tissue:ch1" %in% cols)
+    expect_false("agent:ch1" %in% cols)
+    # ... and the raw characteristics column is retained
+    expect_true(any(grepl("^characteristics_ch1", cols)))
+})


### PR DESCRIPTION
Prototype for the #169 testing strategy — **fixtures-as-code, zero stored data files.**

A `make_fake_series_matrix()` helper writes a few KB of crafted series-matrix text to a `tempfile()`; tests run `parseGSEMatrix(..., getGPL = FALSE)` fully offline. Covers:
- basic parse: dims, sample names, feature names, a value by position
- `parseCharacteristics = TRUE` unpacks `characteristics_ch1` into `tissue:ch1`/`agent:ch1` pData columns
- `parseCharacteristics = FALSE` leaves them unparsed — the regression scaffold for #60 (the forwarding fix will be tested at the `getGEO` level)

Locks the pattern before scaling it across the parser. Being a code change, this also exercises the new `bioc-devel (linux)` container leg on a real test PR.

Surfaced along the way: on the `getGPL = FALSE` path, `parseGSEMatrix` drops `exprs()` rownames while `featureData` keeps the probe names (line 618) — noted in #173.

Relates to #169.