### PR TITLE
fix: thread parseCharacteristics through to parseGSEMatrix (#60)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 
+- `getGEO(parseCharacteristics = FALSE)` now actually skips characteristics parsing. The flag was accepted at the top level but dropped before reaching `parseGSEMatrix()`; it is now threaded through `getAndParseGSEMatrices()` and `parseGEO()` (#60, #175).
 - Fixed error when parsing GSE matrix files with malformed or empty lines between sample metadata (e.g., GSE425). Sample lines are now extracted directly using pattern matching to avoid issues with irregular file formatting.
 
 # GEOquery 2.99.0 (2024-10-01)

--- a/R/getGEO.R
+++ b/R/getGEO.R
@@ -134,6 +134,7 @@ getGEO <- function(GEO = NULL, filename = NULL, destdir = tempdir(), GSElimits =
         }
         filename <- getGEOfile(GEO, destdir = destdir, AnnotGPL = AnnotGPL)
     }
-    ret <- parseGEO(filename, GSElimits, destdir, AnnotGPL = AnnotGPL, getGPL = getGPL)
+    ret <- parseGEO(filename, GSElimits, destdir, AnnotGPL = AnnotGPL, getGPL = getGPL,
+        parseCharacteristics = parseCharacteristics)
     return(ret)
 }

--- a/R/parseGEO.R
+++ b/R/parseGEO.R
@@ -25,6 +25,9 @@
 #' @param AnnotGPL Fetch the annotation GPL if available
 #' @param getGPL Fetch the GPL associated with a GSEMatrix entity (should
 #' remain TRUE for all normal use cases)
+#' @param parseCharacteristics Whether or not to parse the characteristics
+#' information (if available) for a GSE Matrix file. Set to FALSE if you
+#' experience trouble parsing the characteristics.
 #' @return parseGEO returns an object of the associated type.  For example, if
 #' it is passed the text from a GDS entry, a GDS object is returned.
 #' @author Sean Davis
@@ -32,7 +35,8 @@
 #' @keywords IO
 #' 
 #' @export
-parseGEO <- function(fname, GSElimits, destdir = tempdir(), AnnotGPL = FALSE, getGPL = TRUE) {
+parseGEO <- function(fname, GSElimits, destdir = tempdir(), AnnotGPL = FALSE, getGPL = TRUE,
+    parseCharacteristics = TRUE) {
     con <- fileOpen(fname)
     first.entity <- findFirstEntity(con)
     close(con)
@@ -43,7 +47,8 @@ parseGEO <- function(fname, GSElimits, destdir = tempdir(), AnnotGPL = FALSE, ge
     }, platform = {
         parseGPL(fname)
     }, `0` = {
-        parseGSEMatrix(fname, destdir = destdir, AnnotGPL = AnnotGPL, getGPL = getGPL)$eset
+        parseGSEMatrix(fname, destdir = destdir, AnnotGPL = AnnotGPL, getGPL = getGPL,
+            parseCharacteristics = parseCharacteristics)$eset
     }, )
     return(ret)
 }
@@ -450,7 +455,7 @@ getAndParseGSEMatrices <- function(GEO, destdir, AnnotGPL, getGPL = TRUE, parseC
             downloadFile(url, destfile = destfile, mode = "wb")
         }
         ret[[b[i]]] <- parseGSEMatrix(destfile, destdir = destdir, AnnotGPL = AnnotGPL,
-            getGPL = getGPL)$eset
+            getGPL = getGPL, parseCharacteristics = parseCharacteristics)$eset
     }
     return(ret)
 }

--- a/man/parseGEO.Rd
+++ b/man/parseGEO.Rd
@@ -13,7 +13,8 @@ parseGEO(
   GSElimits,
   destdir = tempdir(),
   AnnotGPL = FALSE,
-  getGPL = TRUE
+  getGPL = TRUE,
+  parseCharacteristics = TRUE
 )
 }
 \arguments{
@@ -30,6 +31,10 @@ be used for caching)}
 
 \item{getGPL}{Fetch the GPL associated with a GSEMatrix entity (should
 remain TRUE for all normal use cases)}
+
+\item{parseCharacteristics}{Whether or not to parse the characteristics
+information (if available) for a GSE Matrix file. Set to FALSE if you
+experience trouble parsing the characteristics.}
 }
 \value{
 parseGEO returns an object of the associated type.  For example, if

--- a/tests/testthat/test_parse_synthetic.R
+++ b/tests/testthat/test_parse_synthetic.R
@@ -68,3 +68,18 @@ test_that("parseCharacteristics = FALSE leaves characteristics unparsed (regress
     # ... and the raw characteristics column is retained
     expect_true(any(grepl("^characteristics_ch1", cols)))
 })
+
+test_that("parseGEO threads parseCharacteristics through to parseGSEMatrix (#60)", {
+    # The #60 bug was that parseCharacteristics was accepted at the top level
+    # but dropped before reaching parseGSEMatrix. Exercise the local-file
+    # forwarding path (parseGEO -> parseGSEMatrix) offline via getGPL = FALSE.
+    f <- make_fake_series_matrix()
+
+    eset_off <- GEOquery:::parseGEO(f, GSElimits = NULL, getGPL = FALSE,
+        parseCharacteristics = FALSE)
+    expect_false("tissue:ch1" %in% colnames(Biobase::pData(eset_off)))
+
+    eset_on <- GEOquery:::parseGEO(f, GSElimits = NULL, getGPL = FALSE,
+        parseCharacteristics = TRUE)
+    expect_true("tissue:ch1" %in% colnames(Biobase::pData(eset_on)))
+})


### PR DESCRIPTION
Fixes #60.

`parseGSEMatrix()` has always respected `parseCharacteristics`, but the flag was **dropped on the way down** from `getGEO()`:
- `getAndParseGSEMatrices()` accepted it but didn't pass it to `parseGSEMatrix()`
- `parseGEO()` had no such parameter, so the local-file path (`getGEO(filename=)`) couldn't pass it either

So `getGEO(parseCharacteristics = FALSE)` still parsed characteristics, and could crash (e.g. GSE23397, duplicate identifiers).

**Changes**
- forward `parseCharacteristics` in `getAndParseGSEMatrices()` → `parseGSEMatrix()`
- add `parseCharacteristics` to `parseGEO()` and forward it in the series-matrix branch; `getGEO()` passes it on the local-file path
- roxygen + `man/parseGEO.Rd` for the new argument (regenerated by hand — roxygen2 not available locally; can re-run `/document` if preferred)
- **offline regression test** (`test_parse_synthetic.R`) exercising the `parseGEO` forwarding path via the synthetic fixture from #174 — no network

**Deferred (per maintainer):** no version bump / NEWS-header change; the DESCRIPTION (2.77.6) vs NEWS (2.99.1) lineage reconciliation belongs to the 3.0 batch. NEWS bullet added under the existing header with issue + PR links.

First behavior fix of the 3.0 correctness floor; uses the #169 fixtures-as-code pattern.