### PR TITLE
fix: harden findFirstEntity against non-public/HTML pages (#58)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 
+- `getGEO()` now fails with a clear message when an accession is private, embargoed, or not yet public (NCBI returns an HTML page) instead of mis-parsing it or, in older versions, looping. `findFirstEntity()` is also hardened against a multi-line edge case that could error and against unbounded reads (#58, #176).
 - `getGEO(parseCharacteristics = FALSE)` now actually skips characteristics parsing. The flag was accepted at the top level but dropped before reaching `parseGSEMatrix()`; it is now threaded through `getAndParseGSEMatrices()` and `parseGEO()` (#60, #175).
 - Fixed error when parsing GSE matrix files with malformed or empty lines between sample metadata (e.g., GSE425). Sample lines are now extracted directly using pattern matching to avoid issues with irregular file formatting.
 

--- a/R/parseGEO.R
+++ b/R/parseGEO.R
@@ -220,16 +220,29 @@ parseGSE <- function(fname, GSElimits = NULL) {
 
 
 findFirstEntity <- function(con) {
-    while (TRUE) {
+    # Safety bound: a well-formed file terminates via the length-0 check below,
+    # but a misbehaving connection should not spin forever (see #58).
+    max_chunks <- 100000L
+    for (chunk in seq_len(max_chunks)) {
         line <- suppressWarnings(readLines(con, 100))
         if (length(line) == 0)
             return(0)
+        # An HTML response almost always means the accession is private,
+        # embargoed, not yet public, or does not exist. Fail clearly rather
+        # than mis-parsing the error page as an empty SOFT/series-matrix file
+        # (which previously surfaced as a cryptic downstream error; see #58).
+        if (any(grepl("<!DOCTYPE|<html|not currently public|could not be found",
+            line, ignore.case = TRUE))) {
+            stop("The downloaded content looks like an HTML page, not GEO data. ",
+                "The accession may be private, embargoed, not yet public, or may ",
+                "not exist.")
+        }
         entity.line <- grep("^\\^(DATASET|SAMPLE|SERIES|PLATFORM|ANNOTATION)", line,
             ignore.case = TRUE, value = TRUE, perl = TRUE)
         entity.line <- gsub("annotation", "platform", entity.line, ignore.case = TRUE)
         if (length(entity.line) > 0) {
-            ret <- c(tolower(sub("\\^", "", strsplit(entity.line, " = ")[[1]][1])),
-                strsplit(entity.line, " = ")[[1]][2])
+            parts <- strsplit(entity.line[1], " = ")[[1]]
+            ret <- c(tolower(sub("\\^", "", parts[1])), parts[2])
             return(ret)
         }
         # catch GSE SeriesMatrix files
@@ -237,10 +250,10 @@ findFirstEntity <- function(con) {
             perl = TRUE)
         # Messy, but GSEMatrix files use tab-separation rather than '=' for
         # separation, so if the ' = ' is not present, we presume to have a
-        # GSEMatrix file (return 0)
-        if (length(checkline) > 0) {
-            if (!grepl(" = ", checkline))
-                return(0)
+        # GSEMatrix file (return 0). Use any() so a chunk with more than one
+        # matching line does not error (condition length > 1).
+        if (length(checkline) > 0 && !any(grepl(" = ", checkline))) {
+            return(0)
         }
     }
     return(0)

--- a/tests/testthat/test_findfirstentity.R
+++ b/tests/testthat/test_findfirstentity.R
@@ -1,0 +1,39 @@
+# Offline tests for findFirstEntity() hardening (#58). No network: feed crafted
+# content through a textConnection.
+
+ff <- function(txt) {
+    con <- textConnection(txt)
+    on.exit(close(con))
+    GEOquery:::findFirstEntity(con)
+}
+
+test_that("findFirstEntity errors clearly on an HTML / non-public page (#58)", {
+    html <- c(
+        "<!DOCTYPE html>", "<html><body>",
+        "This record could not be found or is not currently public.",
+        "</body></html>"
+    )
+    expect_error(ff(html), "private|HTML|public|not exist")
+})
+
+test_that("findFirstEntity returns 0 for a series-matrix file", {
+    sm <- c(
+        "!Series_title\tMy series",
+        "!Series_geo_accession\tGSE1",
+        "!series_matrix_table_begin"
+    )
+    expect_equal(ff(sm), 0)
+})
+
+test_that("findFirstEntity detects a SOFT sample entity", {
+    soft <- c("^SAMPLE = GSM12345", "!Sample_title = x")
+    res <- ff(soft)
+    expect_equal(res[1], "sample")
+    expect_equal(res[2], "GSM12345")
+})
+
+test_that("findFirstEntity tolerates multiple !Series_title lines (#58)", {
+    # Two matching lines in one chunk previously errored on `if (!grepl(...))`
+    # because the condition had length > 1 (R >= 4.2).
+    expect_equal(ff(c("!Series_title\tA", "!Series_title\tB")), 0)
+})


### PR DESCRIPTION
Fixes #58.

A private, embargoed, or non-existent accession makes NCBI return an **HTML page** instead of SOFT/series-matrix data. `findFirstEntity()` mis-handled it (and in older versions could loop). Now it:

- **detects HTML/error content** and `stop()`s with a clear, actionable message (private / embargoed / not yet public / does not exist) instead of mis-parsing it as empty data
- replaces the unbounded `while (TRUE)` with a **bounded loop** as a safety net against a misbehaving connection
- uses `!any(grepl(...))` so a chunk with more than one `!Series_title` line no longer errors on a **length > 1 condition** (R >= 4.2)

**Offline tests** (`test_findfirstentity.R`, textConnection-based) cover the HTML/non-public, series-matrix, SOFT-sample, and multi-line cases — no network.

Follow-up: the `stop()` can become a typed condition (`geoquery_private_accession`) once structured conditions land (#170).

No version bump (reconciliation deferred to the 3.0 batch). NEWS bullet added with issue + PR links.