### PR TITLE
fix: tolerate NA in GDS ID_REF in GDS2eSet (#21)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 
+- `GDS2eSet()` no longer fails when a GDS has an `NA` (or empty) value in its `ID_REF` column (e.g. GDS3666). Such values are replaced with a usable feature name instead of producing "row names contain missing values" (#21, #177).
 - `getGEO()` now fails with a clear message when an accession is private, embargoed, or not yet public (NCBI returns an HTML page) instead of mis-parsing it or, in older versions, looping. `findFirstEntity()` is also hardened against a multi-line edge case that could error and against unbounded reads (#58, #176).
 - `getGEO(parseCharacteristics = FALSE)` now actually skips characteristics parsing. The flag was accepted at the top level but dropped before reaching `parseGSEMatrix()`; it is now threaded through `getAndParseGSEMatrices()` and `parseGEO()` (#60, #175).
 - Fixed error when parsing GSE matrix files with malformed or empty lines between sample metadata (e.g., GSE425). Sample lines are now extracted directly using pattern matching to avoid issues with irregular file formatting.

--- a/R/GDS2MA.R
+++ b/R/GDS2MA.R
@@ -40,7 +40,12 @@
     } else {
         expr <- mat
     }
-    rownames(expr) <- as.character(Table(GDS)$ID_REF)
+    ## Guard against NA/empty ID_REF values, which otherwise make row names
+    ## with missing values and break ExpressionSet construction (#21). Mirror
+    ## the handling already used on the series-matrix path.
+    idref <- as.character(Table(GDS)$ID_REF)
+    idref[is.na(idref) | idref == ""] <- "NA"
+    rownames(expr) <- make.unique(idref)
     tmp <- Columns(GDS)
     rownames(tmp) <- as.character(tmp$sample)
     pheno <- new("AnnotatedDataFrame", data = tmp)

--- a/tests/testthat/test_gds_na.R
+++ b/tests/testthat/test_gds_na.R
@@ -1,0 +1,31 @@
+# Offline regression test for #21: an NA in a GDS ID_REF column must not break
+# GDS2eSet(). Build a minimal synthetic GDS object -- no network.
+
+make_fake_gds <- function() {
+    tbl <- data.frame(
+        ID_REF = c("probe_1", "probe_2", NA),
+        IDENTIFIER = c("geneA", "geneB", "geneC"),
+        GSM1 = c(1.0, 2.0, 3.0),
+        GSM2 = c(4.0, 5.0, 6.0),
+        stringsAsFactors = FALSE,
+        check.names = FALSE
+    )
+    cols <- data.frame(sample = c("GSM1", "GSM2"), stringsAsFactors = FALSE)
+    new("GDS",
+        header = list(title = "synthetic GDS", description = "fixture",
+            platform = "GPL000001"),
+        dataTable = new("GEODataTable", columns = cols, table = tbl))
+}
+
+test_that("GDS2eSet tolerates NA in ID_REF (#21)", {
+    gds <- make_fake_gds()
+    eset <- GDS2eSet(gds, getGPL = FALSE)
+
+    expect_s4_class(eset, "ExpressionSet")
+    expect_true(validObject(eset))
+    expect_equal(nrow(Biobase::exprs(eset)), 3L)
+    expect_equal(ncol(Biobase::exprs(eset)), 2L)
+    # the NA ID_REF became a usable, non-missing feature name
+    expect_false(any(is.na(Biobase::featureNames(eset))))
+    expect_true("NA" %in% Biobase::featureNames(eset))
+})


### PR DESCRIPTION
Fixes #21.

A single `NA` (or empty) value in a GDS `ID_REF` column (e.g. **GDS3666**) produced row names with missing values and broke `ExpressionSet` construction:
> Error ... row names contain missing values

`GDS2eSet()` now sanitizes NA/empty `ID_REF` to a usable feature name and `make.unique()`s it — the same handling already used on the series-matrix path (parseGEO.R).

**Offline regression test** (`test_gds_na.R`): builds a minimal synthetic GDS with an NA `ID_REF` and asserts `GDS2eSet(getGPL = FALSE)` returns a valid `ExpressionSet` with no missing feature names. No network.

No version bump (reconciliation deferred to the 3.0 batch). NEWS bullet with issue + PR links.