### PR TITLE
fix: build supplemental-file URLs with url_join, not file.path (#131)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 
+- Supplemental-file URLs are now built with a small `url_join()` helper instead of `file.path()`, which mangled `https://` into `https:/` and produced double slashes. Affects `getGEOSuppFiles(fetch_files = FALSE)` and `getGEOSeriesFileListing()` (#131, #178).
 - `GDS2eSet()` no longer fails when a GDS has an `NA` (or empty) value in its `ID_REF` column (e.g. GDS3666). Such values are replaced with a usable feature name instead of producing "row names contain missing values" (#21, #177).
 - `getGEO()` now fails with a clear message when an accession is private, embargoed, or not yet public (NCBI returns an HTML page) instead of mis-parsing it or, in older versions, looping. `findFirstEntity()` is also hardened against a multi-line edge case that could error and against unbounded reads (#58, #176).
 - `getGEO(parseCharacteristics = FALSE)` now actually skips characteristics parsing. The flag was accepted at the top level but dropped before reaching `parseGSEMatrix()`; it is now threaded through `getAndParseGSEMatrices()` and `parseGEO()` (#60, #175).

--- a/R/getGEOSuppFiles.R
+++ b/R/getGEOSuppFiles.R
@@ -1,5 +1,13 @@
+# Join a base URL and a path (or vector of paths) with a single slash,
+# preserving the scheme's '//'. Unlike file.path(), this does not collapse
+# 'https://' into 'https:/' and does not produce a double slash when the base
+# already ends in '/' (#131). Vectorized over `path`.
+url_join <- function(base, path) {
+    paste0(sub("/+$", "", base), "/", sub("^/+", "", path))
+}
+
 #' get a directory listing from NCBI GEO
-#' 
+#'
 #' This one makes some assumptions about the structure of the HTML response
 #' returned.
 #'
@@ -139,7 +147,7 @@ getGEOSuppFiles <- function(
         ret$GEO <- GEO
         return(ret)
     } else {
-        return(data.frame(fname = fnames, url = file.path(url, fnames)))
+        return(data.frame(fname = fnames, url = url_join(url, fnames)))
     }
 }
 
@@ -163,7 +171,7 @@ getGEOSuppFiles <- function(
 #' @export
 getGEOSeriesFileListing <- function(GSE) {
   url = getGEOSuppFileURL(GSE)
-  ret <- readr::read_tsv(file.path(url,'filelist.txt'))
+  ret <- readr::read_tsv(url_join(url, 'filelist.txt'))
   ret |> 
     dplyr::rename_with(tolower) |>
     dplyr::rename('archive_or_file'='#archive/file')

--- a/tests/testthat/test_url_join.R
+++ b/tests/testthat/test_url_join.R
@@ -1,0 +1,25 @@
+# Offline tests for url_join() (#131): joining URLs must not collapse the
+# scheme's '//' (as file.path/fs::path do) nor produce a double slash.
+
+test_that("url_join keeps a single slash and preserves the scheme (#131)", {
+    base <- "https://ftp.ncbi.nlm.nih.gov/geo/series/GSE48nnn/GSE48350/suppl/"
+    expect_equal(
+        GEOquery:::url_join(base, "GSE48350_RAW.tar"),
+        "https://ftp.ncbi.nlm.nih.gov/geo/series/GSE48nnn/GSE48350/suppl/GSE48350_RAW.tar"
+    )
+    # scheme '//' intact, no '//' after it
+    expect_false(grepl("[^:]//", GEOquery:::url_join(base, "x")))
+})
+
+test_that("url_join works whether or not the base has a trailing slash", {
+    expect_equal(GEOquery:::url_join("https://a.b/c/", "d"), "https://a.b/c/d")
+    expect_equal(GEOquery:::url_join("https://a.b/c", "d"), "https://a.b/c/d")
+})
+
+test_that("url_join strips a leading slash on the path and is vectorized", {
+    expect_equal(GEOquery:::url_join("https://a.b/c/", "/d"), "https://a.b/c/d")
+    expect_equal(
+        GEOquery:::url_join("https://a.b/c/", c("d", "e")),
+        c("https://a.b/c/d", "https://a.b/c/e")
+    )
+})


### PR DESCRIPTION
Fixes #131.

`file.path(url, ...)` mangles `https://` → `https:/` and produces a double slash when the base ends in `/`. Two call sites returned such broken URLs:
- `getGEOSuppFiles(fetch_files = FALSE)` — the `url` column
- `getGEOSeriesFileListing()` — the `filelist.txt` URL

Adds a small vectorized `url_join()` helper that preserves the scheme and joins with a single slash. The actual download path already used `httr2::req_url_path_append()` and was correct.

**Note on the original issue:** the suggested `fs::path` fix is itself wrong — `fs::path` *also* collapses `https://` → `https:/`. `url_join()` is the correct fix.

**Offline tests** cover the scheme-preservation, trailing-slash, leading-slash, and vectorized cases.

No version bump (reconciliation deferred to the 3.0 batch). NEWS bullet with issue + PR links.