### PR TITLE
ci: stop GEOquery.qmd executing live network during R CMD check

### DIFF
--- a/vignettes/GEOquery.qmd
+++ b/vignettes/GEOquery.qmd
@@ -6,6 +6,12 @@ last-modified: {{< meta last-modified >}}
 format:
   html:
     toc: true
+# TEMPORARY: code chunks are not executed so that `R CMD check`'s per-vignette
+# rebuild does not make live NCBI calls (intermittent CI failures). This makes
+# the vignette code-only for now. Restore executed output via a pkgdown article
+# or a verified freeze setup -- tracked in #156.
+execute:
+  eval: false
 vignette: >
   %\VignetteIndexEntry{Using GEOquery (Quarto)}
   %\VignetteEngine{quarto::html}


### PR DESCRIPTION
`GEOquery.qmd` executed live `getGEO()` / `searchGEO()` / `getGEOSuppFiles()` calls during the per-vignette quarto rebuild in `R CMD check`. Any NCBI hiccup failed the **required** bioc-devel/macOS leg — intermittent red on every code PR (it just bit #178, where 274/274 tests passed).

Sets document-level `execute: eval: false` (as `single-cell.qmd` already does) so the vignette no longer hits the network at check time.

**Trade-off (temporary):** the vignette is now code-only — no rendered output. Restoring executed output is **tracked in #156**. Note for the record: Quarto `freeze` does **not** solve this, because `freeze` only applies to full-project renders while `R CMD check` rebuilds each vignette as a single document (always executed). The durable fix is a pkgdown article (`vignettes/articles/`) that R CMD check never builds.

No version bump (build/CI hygiene).