### PR TITLE
feat: add quiet argument to getGEOSuppFiles (#68)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GEOquery
 Type: Package
 Title: Get data from NCBI Gene Expression Omnibus (GEO)
-Version: 2.77.8
+Version: 2.77.9
 Date: 2026-06-13
 Authors@R: 
   c(person(given = "Sean",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # GEOquery (development version)
 
+## New features
+
+- `getGEOSuppFiles()` gains a `quiet` argument (defaulting to the `GEOquery.quiet` option, or `FALSE`) to suppress informational messages such as "No supplemental files found" and "Using locally cached version" (#68, #182).
+
 ## Documentation
 
 - The package `DESCRIPTION` and `biocViews` now describe GEOquery's actual scope (microarray, RNA-seq, and single-cell; GEO Series Matrix files parsed to `ExpressionSet` by default) instead of microarray-only (#71, #181).

--- a/R/getGEOSuppFiles.R
+++ b/R/getGEOSuppFiles.R
@@ -81,6 +81,9 @@ getGEOSuppFileURL <- function(GEO) {
 #'     files. If FALSE, just return the filenames that would have been
 #'     downloaded. Useful for testing and getting a list of files
 #'     without actual download.
+#' @param quiet logical(1). If TRUE, suppress informational messages such as
+#'     "No supplemental files found" and "Using locally cached version".
+#'     Defaults to the `GEOquery.quiet` option, or FALSE.
 #' @return If fetch_files=TRUE, a data frame is returned invisibly with rownames representing the
 #' full path of the resulting downloaded files and the records in the
 #' data.frame the output of file.info for each downloaded file.
@@ -102,7 +105,8 @@ getGEOSuppFiles <- function(
     makeDirectory = TRUE,
     baseDir = getwd(),
     fetch_files = TRUE,
-    filter_regex = NULL
+    filter_regex = NULL,
+    quiet = getOption("GEOquery.quiet", FALSE)
 ) {
     geotype <- toupper(substr(GEO, 1, 3))
     storedir <- baseDir
@@ -110,9 +114,11 @@ getGEOSuppFiles <- function(
     url <- getGEOSuppFileURL(GEO)
     fnames <- try(getDirListing(url), silent = TRUE)
     if (inherits(fnames, "try-error")) {
-        message("No supplemental files found.")
-        message("Check URL manually if in doubt")
-        message(url)
+        if (!quiet) {
+            message("No supplemental files found.")
+            message("Check URL manually if in doubt")
+            message(url)
+        }
         return(NULL)
     }
     if (makeDirectory) {
@@ -134,8 +140,10 @@ getGEOSuppFiles <- function(
                       httr2::req_perform(path=destfile)
                     res <- 0
                 } else {
-                  message(sprintf("Using locally cached version of supplementary file(s) %s found here:\n%s ",
-                    GEO, destfile))
+                  if (!quiet) {
+                    message(sprintf("Using locally cached version of supplementary file(s) %s found here:\n%s ",
+                      GEO, destfile))
+                  }
                     res <- 0
                 }
             fileinfo[[destfile]] <- file.info(destfile)

--- a/man/getGEOSuppFiles.Rd
+++ b/man/getGEOSuppFiles.Rd
@@ -9,7 +9,8 @@ getGEOSuppFiles(
   makeDirectory = TRUE,
   baseDir = getwd(),
   fetch_files = TRUE,
-  filter_regex = NULL
+  filter_regex = NULL,
+  quiet = getOption("GEOquery.quiet", FALSE)
 )
 }
 \arguments{
@@ -31,6 +32,10 @@ without actual download.}
 used to filter the filenames from GEO to limit those files that
 will be downloaded. This is useful to limit to, for example,
 bed files only.}
+
+\item{quiet}{logical(1). If TRUE, suppress informational messages such as
+"No supplemental files found" and "Using locally cached version".
+Defaults to the `GEOquery.quiet` option, or FALSE.}
 }
 \value{
 If fetch_files=TRUE, a data frame is returned invisibly with rownames representing the


### PR DESCRIPTION
Closes #68. Adds `quiet = getOption("GEOquery.quiet", FALSE)` to suppress informational messages. Roxygen + Rd updated. Bumps to 2.77.9. (Offline test deferred to #173 — the messages are on network paths and need the HTTP layer mockable.)