### PR TITLE
test: confirm getGPL = FALSE skips GPL for local series matrix (#18)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GEOquery
 Type: Package
 Title: Get data from NCBI Gene Expression Omnibus (GEO)
-Version: 2.77.9
+Version: 2.77.10
 Date: 2026-06-13
 Authors@R: 
   c(person(given = "Sean",

--- a/tests/testthat/test_parse_synthetic.R
+++ b/tests/testthat/test_parse_synthetic.R
@@ -46,6 +46,18 @@ test_that("parseGSEMatrix parses a synthetic series matrix offline (getGPL = FAL
     expect_equal(unname(Biobase::exprs(eset)[1, 1]), 1.5)
 })
 
+test_that("getGPL = FALSE skips GPL annotation for a local series matrix (#18)", {
+    # Regression guard for #18: with getGPL = FALSE the parser must not fetch a
+    # GPL, so featureData has zero columns. parseGEO is the path getGEO() uses
+    # for a local filename. Runs offline (no GPL is requested).
+    f <- make_fake_series_matrix(n_features = 3)
+    eset <- GEOquery:::parseGEO(f, GSElimits = NULL, getGPL = FALSE)
+
+    expect_s4_class(eset, "ExpressionSet")
+    expect_equal(ncol(Biobase::fData(eset)), 0L)
+    expect_equal(nrow(Biobase::fData(eset)), 3L)
+})
+
 test_that("parseCharacteristics = TRUE unpacks characteristics_ch1 into pData columns", {
     f <- make_fake_series_matrix()
     eset <- GEOquery:::parseGSEMatrix(f, getGPL = FALSE, parseCharacteristics = TRUE)$eset


### PR DESCRIPTION
Closes #18. The reported bug (getGPL=FALSE still fetching the GPL on a local file) no longer reproduces — the current code forwards `getGPL` correctly through `parseGEO` -> `parseGSEMatrix`, leaving featureData empty. Adds an **offline** regression test via the synthetic fixture to lock it. No code change; bumps to 2.77.10.