### PR TITLE
test: gate live-network tests behind GEOQUERY_INTEGRATION (#169)

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,38 @@
+# Live-network integration tests against NCBI GEO. These are the tests gated by
+# skip_if_no_integration() (issue #169): they are non-deterministic and so are
+# kept out of PR CI. This workflow runs them on a schedule (to catch GEO format
+# drift / outages) and on demand. It does not gate any pull request.
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # weekly, Monday 06:00 UTC
+  workflow_dispatch:
+
+name: integration
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    container:
+      image: bioconductor/bioconductor_docker:devel
+    env:
+      GEOQUERY_INTEGRATION: "true"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          options(repos = BiocManager::repositories())
+          install.packages(c("remotes", "rcmdcheck"))
+          remotes::install_deps(dependencies = TRUE)
+        shell: Rscript {0}
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GEOquery
 Type: Package
 Title: Get data from NCBI Gene Expression Omnibus (GEO)
-Version: 2.77.11
+Version: 2.77.12
 Date: 2026-06-13
 Authors@R: 
   c(person(given = "Sean",

--- a/tests/testthat/helper-integration.R
+++ b/tests/testthat/helper-integration.R
@@ -1,0 +1,10 @@
+# Live-network ("integration") tests hit NCBI GEO and are non-deterministic in
+# CI. They run only when GEOQUERY_INTEGRATION=true (set by the scheduled
+# integration workflow), and never on CRAN. Offline/synthetic tests are
+# unaffected. See issue #169.
+skip_if_no_integration <- function() {
+    testthat::skip_on_cran()
+    if (!identical(Sys.getenv("GEOQUERY_INTEGRATION"), "true")) {
+        testthat::skip("live-network integration test; set GEOQUERY_INTEGRATION=true to run")
+    }
+}

--- a/tests/testthat/test_GEO_conversions.R
+++ b/tests/testthat/test_GEO_conversions.R
@@ -3,6 +3,7 @@ library(limma)
 context('GEO conversions')
 
 test_that("GDS2eSet works", {
+    skip_if_no_integration()
     gds = getGEO(filename=system.file("extdata/GDS507.soft.gz",package="GEOquery"))
 
     eset = GDS2eSet(gds)
@@ -14,6 +15,7 @@ test_that("GDS2eSet works", {
 })
     
 test_that("GDS2MA works", {
+    skip_if_no_integration()
     gds = getGEO(filename=system.file("extdata/GDS507.soft.gz",package="GEOquery"))
     
     malist = GDS2MA(gds)

--- a/tests/testthat/test_GPL.R
+++ b/tests/testthat/test_GPL.R
@@ -2,6 +2,7 @@ library(GEOquery)
 context('GPL')
 
 test_that("generic GPL parsing works as expected", {
+    skip_if_no_integration()
     gpl = getGEO('GPL96')
     
     expect_is(gpl,'GPL') #gpl is not a GPL object!')
@@ -14,12 +15,14 @@ test_that("generic GPL parsing works as expected", {
 })
 
 test_that("quoted GPL works", {
+    skip_if_no_integration()
     gpl = getGEO('GPL4133')
 
     expect_equivalent(45220,nrow(Table(gpl))) #GPL4133 should have 45220 rows
 })
 
 test_that("short GPL works", {
+    skip_if_no_integration()
     gpl = getGEO('GPL15505')
     
     expect_is(gpl,'GPL')
@@ -27,6 +30,7 @@ test_that("short GPL works", {
 })
 
 test_that("GPL with no data table works", {
+    skip_if_no_integration()
     gpl = getGEO("GPL5082")
     
     expect_is(gpl,'GPL')

--- a/tests/testthat/test_GSE.R
+++ b/tests/testthat/test_GSE.R
@@ -3,6 +3,7 @@ context("GSE")
 
 
 test_that("empty GSE is handled correctly", {
+    skip_if_no_integration()
     gse = getGEO('GSE11413')
 
     expect_is(gse, 'list')
@@ -12,12 +13,14 @@ test_that("empty GSE is handled correctly", {
 })
 
 test_that("case-mismatched IDs in GSEs handled correctly", {
+    skip_if_no_integration()
     gse = getGEO('GSE35683')
 
     expect_equivalent(nrow(gse[[1]]), 54675)
 })
 
 test_that("single-sample GSE handled correctly", {
+    skip_if_no_integration()
     gse = getGEO("GSE11595")
     
     expect_is(gse[[1]], "ExpressionSet")
@@ -25,12 +28,14 @@ test_that("single-sample GSE handled correctly", {
 })
 
 test_that("short GSE handled correctly", {
+    skip_if_no_integration()
     gse = getGEO("GSE34145")
 
     expect_equivalent(nrow(gse[[1]]), 15)
 })
 
 test_that("generic SOFT format GSE handled correctly", {
+    skip_if_no_integration()
     gse = getGEO('GSE1563',GSEMatrix=FALSE)
 
     expect_equal(62, length(GSMList(gse)))
@@ -44,6 +49,7 @@ test_that("generic SOFT format GSE handled correctly", {
 })
 
 test_that("GSE with more than one value per characteristic handled", {
+    skip_if_no_integration()
   gse = getGEO("GSE71989")
   
   expect_equivalent(nrow(gse[[1]]), 54675)
@@ -52,6 +58,7 @@ test_that("GSE with more than one value per characteristic handled", {
 
 
 test_that("GSE has populated experimentData", {
+    skip_if_no_integration()
   gse = getGEO("GSE53986")
   
   ed <- experimentData(gse[[1]])
@@ -66,6 +73,7 @@ test_that("GSE has populated experimentData", {
 })
 
 test_that("GSE populates experimentData as much as possible", {
+    skip_if_no_integration()
   gse = getGEO("GSE99709")
   
   ed <- experimentData(gse[[1]])
@@ -99,6 +107,7 @@ test_that("Empty files produces an error", {
 })
 
 test_that("GSE/GPL with integer64 columns handled correctly", {
+    skip_if_no_integration()
   gse = getGEO("GSE7864")[[1]]
   fdata = fData(gse)
   expect_s3_class(fdata$ID, "integer64")
@@ -106,12 +115,14 @@ test_that("GSE/GPL with integer64 columns handled correctly", {
 })
 
 test_that("Test regression against issue 144", {
+    skip_if_no_integration()
   gse = getGEO("GSE225759")[[1]]
   expect_equivalent(nrow(gse), 442)
   expect_equivalent(ncol(gse), 272)
 })
 
 test_that("GSE425 parsing with malformed sample lines", {
+    skip_if_no_integration()
   gse = getGEO("GSE425")
   expect_is(gse, 'list')
   expect_is(gse[[1]], 'ExpressionSet')

--- a/tests/testthat/test_GSM.R
+++ b/tests/testthat/test_GSM.R
@@ -2,6 +2,7 @@ library(testthat)
 context('GSM')
 
 test_that("basic GSM works", {
+    skip_if_no_integration()
     gsm = getGEO('GSM11805')
 
     expect_is(gsm,'GSM')

--- a/tests/testthat/test_fetch_GPL_false.R
+++ b/tests/testthat/test_fetch_GPL_false.R
@@ -2,6 +2,7 @@ library(GEOquery)
 context('get records without GPL')
 
 test_that("GSE without GPL works", {
+    skip_if_no_integration()
     gse = getGEO('GSE2553',getGPL=FALSE)[[1]]
     
     expect_true(validObject(gse))
@@ -11,6 +12,7 @@ test_that("GSE without GPL works", {
 
 
 test_that("GDS without GPL works", {
+    skip_if_no_integration()
     gds = getGEO('GDS10')
     
     eset = GDS2eSet(gds,getGPL=FALSE)

--- a/tests/testthat/test_geo_rnaseq.R
+++ b/tests/testthat/test_geo_rnaseq.R
@@ -2,6 +2,7 @@ library(testthat)
 context("geo_rnaseq")
 
 test_that("getGSEDownloadPageURLs returns character vector", {
+    skip_if_no_integration()
   gse <- "GSE83322"
   result <- getGSEDownloadPageURLs(gse)
 
@@ -10,6 +11,7 @@ test_that("getGSEDownloadPageURLs returns character vector", {
 })
 
 test_that("getRNAQuantRawCountsURL returns character vector", {
+    skip_if_no_integration()
   gse <- "GSE83322"
   links <- getGSEDownloadPageURLs(gse)
   result <- getRNAQuantRawCountsURL(links)
@@ -19,6 +21,7 @@ test_that("getRNAQuantRawCountsURL returns character vector", {
 })
 
 test_that("getRNAQuantAnnotationURL returns character vector", {
+    skip_if_no_integration()
   gse <- "GSE83322"
   links <- getGSEDownloadPageURLs(gse)
   result <- getRNAQuantAnnotationURL(links)
@@ -30,6 +33,7 @@ test_that("getRNAQuantAnnotationURL returns character vector", {
 links <- getGSEDownloadPageURLs("GSE83322")
 
 test_that("readRNAQuantRawCounts returns matrix", {
+    skip_if_no_integration()
   link <- getRNAQuantRawCountsURL(links)
   result <- readRNAQuantRawCounts(link)
 
@@ -39,6 +43,7 @@ test_that("readRNAQuantRawCounts returns matrix", {
 })
 
 test_that("readRNAQuantAnnotation returns data.frame", {
+    skip_if_no_integration()
   link <- getRNAQuantAnnotationURL(links)
   result <- readRNAQuantAnnotation(link)
 
@@ -48,6 +53,7 @@ test_that("readRNAQuantAnnotation returns data.frame", {
 })
 
 test_that("getRNASeqQuantResults returns list", {
+    skip_if_no_integration()
   gse <- "GSE83322"
   result <- getRNASeqQuantResults(gse)
 
@@ -58,6 +64,7 @@ test_that("getRNASeqQuantResults returns list", {
 })
 
 test_that("getRNASeqData returns SummarizedExperiment", {
+    skip_if_no_integration()
   gse <- "GSE83322"
   result <- getRNASeqData(gse)
 
@@ -67,6 +74,7 @@ test_that("getRNASeqData returns SummarizedExperiment", {
 })
 
 test_that("hasRNASeqQuantifications returns logical", {
+    skip_if_no_integration()
   gse <- "GSE83322"
   result <- hasRNASeqQuantifications(gse)
 
@@ -74,6 +82,7 @@ test_that("hasRNASeqQuantifications returns logical", {
 })
 
 test_that("hasRNASeqQuantifications returns TRUE for GSE83322", {
+    skip_if_no_integration()
   gse <- "GSE83322"
   result <- hasRNASeqQuantifications(gse)
 
@@ -81,6 +90,7 @@ test_that("hasRNASeqQuantifications returns TRUE for GSE83322", {
 })
 
 test_that("hasRNASeqQuantifications returns FALSE for GSE2553", {
+    skip_if_no_integration()
   gse <- "GSE2553"
   result <- hasRNASeqQuantifications(gse)
 
@@ -88,6 +98,7 @@ test_that("hasRNASeqQuantifications returns FALSE for GSE2553", {
 })
 
 test_that("getRNASeqQuantGenomeInfo returns correct data", {
+    skip_if_no_integration()
   genome_info <- getRNASeqQuantGenomeInfo("GSE83322")
 
   expect_length(genome_info, 3)

--- a/tests/testthat/test_supp_files.R
+++ b/tests/testthat/test_supp_files.R
@@ -2,27 +2,32 @@ library(testthat)
 context('GEO supplementary files')
 
 test_that("GSE Supplemental files downloading works", {
+    skip_if_no_integration()
     res = getGEOSuppFiles('GSE1000')
     expect_equivalent(nrow(res), 1)
 })
 
 test_that("GSM Supplemental files downloading works", {
+    skip_if_no_integration()
     res = getGEOSuppFiles('GSM15789')
     expect_equivalent(nrow(res), 1)
 })
 
 test_that("GSM Supplemental files downloading to baseDir works", {
+    skip_if_no_integration()
     res = getGEOSuppFiles('GSM15789', baseDir=tempdir())
     expect_equivalent(nrow(res), 1)
 })
 
 test_that("GSE supplemental file no-download works", {
+    skip_if_no_integration()
     res = getGEOSuppFiles('GSE63137', fetch_files = FALSE)
     expect_equivalent(nrow(res), 12)
     expect_equivalent(ncol(res), 2)
 })
 
 test_that("GSE Supplemental file filtering works", {
+    skip_if_no_integration()
     res = getGEOSuppFiles('GSE63137', fetch_files = FALSE, filter_regex = 'txt.gz')
     expect_equivalent(ncol(res), 2)
     expect_equivalent(nrow(res), 4)


### PR DESCRIPTION
The live-NCBI tests are non-deterministic and intermittently fail PR CI (just cost reruns on #184 — a transient `getGEO("GSE53986")`). This makes PR CI deterministic.

**What:**
- `skip_if_no_integration()` helper — skips unless `GEOQUERY_INTEGRATION=true`, always skips on CRAN.
- Applied to the network-dependent tests in `test_GSE`, `test_GPL`, `test_GSM`, `test_GEO_conversions` (GDS2eSet/GDS2MA fetch the GPL), `test_fetch_GPL_false`, `test_geo_rnaseq`, `test_supp_files`.
- **Left running on every PR:** offline/bundled-data tests — all of `test_GDS`, the `GPLbroken` case in `test_GSE`, and the new synthetic suites.
- New weekly **`integration` workflow** (Bioc devel container, sets the env) runs the live suite on schedule + on demand, so GEO format drift is still caught — off the PR critical path.

**Validates itself:** this PR's own `bioc-devel` leg now *skips* the gated tests (env unset) and runs only the deterministic offline ones.

Bumps to 2.77.12. **Refs #169** (Tier-3 gating; Tier-2 httptest2 mocks still come with #173).