### PR TITLE
refactor: shared httr2 HTTP layer — streaming, retry, typed errors (#173)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GEOquery
 Type: Package
 Title: Get data from NCBI Gene Expression Omnibus (GEO)
-Version: 2.77.12
+Version: 2.77.13
 Date: 2026-06-13
 Authors@R: 
   c(person(given = "Sean",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 ## New features
 
-- GEOquery now raises typed error conditions — `geoquery_error` and subclasses (`geoquery_private_accession`, `geoquery_download_error`, `geoquery_parse_error`, `geoquery_bad_accession`) — so failures can be handled programmatically with `tryCatch()`. The non-public/private-accession error from `getGEO()` is the first to use them (#170, #184).
+- Downloads now stream to disk instead of buffering the entire response in memory, retry on transient HTTP errors, and honor a configurable `GEOquery.download.timeout` option (default 300 seconds) — replacing the previous enforced 120-second floor that ignored lower user timeouts. Failures raise a typed `geoquery_download_error` carrying the URL and HTTP status. `getDirListing()` now uses the same httr2 layer (#147, #173).
+- GEOquery now raises typed error conditions — `geoquery_error` and subclasses (`geoquery_private_accession`, `geoquery_download_error`, `geoquery_parse_error`, `geoquery_bad_accession`) — so failures can be handled programmatically with `tryCatch()` (#170, #184, #186).
+- `getGEOSuppFiles()` gains a `quiet` argument (defaulting to the `GEOquery.quiet` option, or `FALSE`) to suppress informational messages such as "No supplemental files found" and "Using locally cached version" (#68, #182).
 - `getGEOSuppFiles()` gains a `quiet` argument (defaulting to the `GEOquery.quiet` option, or `FALSE`) to suppress informational messages such as "No supplemental files found" and "Using locally cached version" (#68, #182).
 
 ## Documentation

--- a/R/getGEOSuppFiles.R
+++ b/R/getGEOSuppFiles.R
@@ -16,9 +16,12 @@ url_join <- function(base, path) {
 #' 
 #' @importFrom xml2 read_html xml_text xml_find_all 
 getDirListing <- function(url) {
-    # Takes a URL and returns a character vector of filenames
-    a <- xml2::read_html(url)
-    fnames = grep("^G", xml_text(xml_find_all(a, "//a/@href")), value = TRUE)
+    # Fetch the index page through the shared httr2 request (.geo_request) so it
+    # uses the same timeout/retry handling as downloadFile and can be mocked in
+    # tests (#173). Returns a character vector of GEO filenames.
+    resp <- httr2::req_perform(.geo_request(url))
+    a <- xml2::read_html(httr2::resp_body_string(resp))
+    fnames <- grep("^G", xml2::xml_text(xml2::xml_find_all(a, "//a/@href")), value = TRUE)
     return(fnames)
 }
 

--- a/R/getGEOfile.R
+++ b/R/getGEOfile.R
@@ -131,40 +131,42 @@ getGEORaw <- function(GEO, destdir = tempdir()) {
 }
 
 
-# internal use only
-downloadFile <- function(url, destfile, mode, quiet = TRUE) {
-  timeout_seconds <- max(getOption("timeout"), 120)
+# Build a configured httr2 request for an NCBI GEO URL: a courtesy user-agent,
+# an option-driven timeout (no artificial floor; see #147), and retries on
+# transient failures. Returning the request object (rather than performing it)
+# keeps callers mockable via httr2::with_mocked_responses() (#173).
+.geo_request <- function(url, timeout = getOption("GEOquery.download.timeout", 300)) {
+  httr2::request(url) |>
+    httr2::req_user_agent("GEOquery (https://github.com/seandavi/GEOquery)") |>
+    httr2::req_timeout(timeout) |>
+    httr2::req_retry(
+      max_tries = 3,
+      is_transient = function(resp) httr2::resp_status(resp) %in% c(429, 500, 502, 503, 504)
+    )
+}
 
-  result <- tryCatch(
-    {
-      req <- httr2::request(url) %>%
-        httr2::req_headers(`accept-encoding` = "gzip") %>%
-        httr2::req_timeout(timeout_seconds)
-
-      resp <- httr2::req_perform(req)
-
-      if (httr2::resp_status(resp) == 200) {
-        writeBin(httr2::resp_body_raw(resp), destfile)
-        return(TRUE)
-      } else {
-        stop("Failed to download file: ", httr2::resp_status(resp))
-      }
-    },
+# internal use only. `mode` is accepted for backward compatibility and ignored
+# (the response is streamed to disk in binary). On failure the partial file is
+# removed and a typed `geoquery_download_error` is raised (#170, #173).
+downloadFile <- function(url, destfile, mode = "wb", quiet = TRUE,
+    timeout = getOption("GEOquery.download.timeout", 300)) {
+  req <- .geo_request(url, timeout) |>
+    httr2::req_headers(`accept-encoding` = "gzip")
+  tryCatch(
+    httr2::req_perform(req, path = destfile),
     error = function(e) {
-      message(e)
-      return(FALSE)
+      if (file.exists(destfile)) {
+        file.remove(destfile)
+      }
+      status <- tryCatch(httr2::resp_status(e$resp), error = function(...) NULL)
+      .abort_download(
+        sprintf("Failed to download '%s'.", url),
+        url = url, status = status, parent = e
+      )
     }
   )
-
-  message("File stored at:")
-  message(destfile)
-
-  ## if the download failed, remove the corrupted file and report the error
-  if (!result) {
-    if (file.exists(destfile)) {
-      file.remove(destfile)
-    }
-    stop(sprintf("Failed to download %s!", destfile))
+  if (!quiet) {
+    message("File stored at: ", destfile)
   }
-  return(0)
+  invisible(TRUE)
 }

--- a/tests/testthat/test_http.R
+++ b/tests/testthat/test_http.R
@@ -1,0 +1,38 @@
+# Offline tests for the shared HTTP layer (#173). httr2's own mocking is used,
+# so no network and no extra dependency.
+
+test_that("getDirListing parses GEO-prefixed hrefs from a mocked index (#173)", {
+    html <- paste0(
+        "<html><body>",
+        "<a href=\"GSE1_RAW.tar\">GSE1_RAW.tar</a>",
+        "<a href=\"filelist.txt\">filelist.txt</a>",
+        "</body></html>"
+    )
+    httr2::with_mocked_responses(
+        function(req) httr2::response(200, body = charToRaw(html)),
+        {
+            fnames <- GEOquery:::getDirListing("https://ftp.ncbi.nlm.nih.gov/x/")
+            expect_true("GSE1_RAW.tar" %in% fnames)
+            # filtered: only names starting with "G" are returned
+            expect_false("filelist.txt" %in% fnames)
+        }
+    )
+})
+
+test_that("downloadFile succeeds on a mocked 200 response (#173)", {
+    res <- httr2::with_mocked_responses(
+        function(req) httr2::response(200, body = charToRaw("payload")),
+        GEOquery:::downloadFile("https://example.com/f", tempfile())
+    )
+    expect_true(res)
+})
+
+test_that("downloadFile raises a typed geoquery_download_error on HTTP failure (#173, #170)", {
+    httr2::with_mocked_responses(
+        function(req) httr2::response(404),
+        expect_error(
+            GEOquery:::downloadFile("https://example.com/missing", tempfile()),
+            class = "geoquery_download_error"
+        )
+    )
+})


### PR DESCRIPTION
Closes #173, #147, #170 — the download/dir-listing cluster.

Introduces `.geo_request()`, a configured httr2 request (courtesy user-agent, option-driven timeout, transient retry) shared by `downloadFile()` and `getDirListing()`:

- **`downloadFile`** streams to disk (`req_perform(path=)`) instead of buffering the whole response in memory (`resp_body_raw`) — avoids OOM on large `family.soft.gz`. Retries transient failures and raises a typed **`geoquery_download_error`** (carrying `url` + `status`) instead of a generic `stop()`. (#170)
- **#147**: the `max(getOption("timeout"), 120)` floor is removed. Timeout is `getOption("GEOquery.download.timeout", 300)` plus a `timeout` argument — no floor, lower user values respected.
- **`getDirListing`** now fetches through `.geo_request` (previously bare `xml2::read_html(url)`), so it shares timeout/retry handling **and is mockable**.

**Offline tests** (`test_http.R`) use `httr2::with_mocked_responses` — no new dependency — covering dir-listing parse, a mocked success, and the typed 404 error. This is the **Tier-2 mocking** that #169 needed and that the unmockable `getDirListing` previously blocked.

Bumps to 2.77.13. First PR to run on the fully deterministic CI (post-#185).