### PR TITLE
docs: fill in class and accessor documentation (#103)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GEOquery
 Type: Package
 Title: Get data from NCBI Gene Expression Omnibus (GEO)
-Version: 2.77.18
+Version: 2.77.19
 Date: 2026-06-13
 Authors@R: 
   c(person(given = "Sean",

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 
 ## Documentation
 
+- The S4 class and accessor documentation is filled in: the `GEOData` accessors (`Meta`, `Table`, `Columns`, `dataTable`, `Accession`, `GSMList`, `GPLList`) now have real descriptions, return values, and examples, and the class pages no longer imply constructing objects with `new()` — they are returned by `getGEO()` (#103, #192).
 - Documentation is reorganized into narrative pkgdown **articles** — *Understanding GEO data formats*, *RNA-seq quantifications*, *Single-cell data from GEO*, and *From GEO to downstream analysis* — that cover the *why* (entity types, file formats) and downstream workflows with links to other Bioconductor packages. The package vignette is now a concise quick-start that indexes them; the articles render on the pkgdown site and are excluded from `R CMD check` (#156, #191).
 
 - The package `DESCRIPTION` and `biocViews` now describe GEOquery's actual scope (microarray, RNA-seq, and single-cell; GEO Series Matrix files parsed to `ExpressionSet` by default) instead of microarray-only (#71, #181).

--- a/R/GEOquery-package.R
+++ b/R/GEOquery-package.R
@@ -1,14 +1,49 @@
 
 
-#' Generic functions for GEOquery
-#' 
-#' The main documentation is in the Class documentation
-#' 
+#' Accessors for GEOquery objects
+#'
+#' Accessor generics for the S4 objects returned by \code{\link{getGEO}} when
+#' parsing SOFT-format records (\code{GSE}, \code{GSM}, \code{GPL}, \code{GDS}).
+#' Use these rather than reaching into slots directly.
+#'
+#' \describe{
+#'   \item{\code{Meta(object)}}{The record metadata as a named list (title,
+#'     submission dates, sample/platform attributes, and so on).}
+#'   \item{\code{Accession(object)}}{The GEO accession (the
+#'     \code{geo_accession} metadata field).}
+#'   \item{\code{Table(object)}}{The data table as a \code{data.frame} -- for
+#'     example the measurement table of a \code{GSM} or the probe annotation of
+#'     a \code{GPL}.}
+#'   \item{\code{Columns(object)}}{A \code{data.frame} describing the columns of
+#'     \code{Table(object)}.}
+#'   \item{\code{dataTable(object)}}{The underlying \code{GEODataTable} object,
+#'     which holds both \code{Table()} and \code{Columns()}.}
+#'   \item{\code{GSMList(object)}}{For a \code{GSE}, the list of its \code{GSM}
+#'     sample objects.}
+#'   \item{\code{GPLList(object)}}{For a \code{GSE}, the list of its \code{GPL}
+#'     platform objects.}
+#' }
+#'
+#' @param object A GEOquery S4 object (\code{GSE}, \code{GSM}, \code{GPL},
+#'   \code{GDS}, or \code{GEODataTable}).
+#' @return \code{Meta()} a list; \code{Accession()} a character string;
+#'   \code{Table()} and \code{Columns()} data.frames; \code{dataTable()} a
+#'   \code{GEODataTable}; \code{GSMList()} and \code{GPLList()} named lists.
 #' @name GEOData-accessors
 #' @aliases dataTable Accession Columns GPLList GSMList Meta Table
 #' @author Sean Davis
-#' @seealso \code{\link{GEOData-class}}
+#' @seealso \code{\link{GEOData-class}}, \code{\link{getGEO}}
 #' @keywords IO
+#' @examples
+#' \dontrun{
+#'   gsm <- getGEO("GSM11805")
+#'   Meta(gsm)$title
+#'   head(Table(gsm))
+#'   Columns(gsm)
+#'
+#'   gse <- getGEO("GSE781", GSEMatrix = FALSE)
+#'   names(GSMList(gse))
+#' }
 NULL
 
 
@@ -22,8 +57,8 @@ NULL
 #' 
 #' @name GDS-class
 #' @docType class
-#' @section Objects from the Class: Objects can be created by calls of the form
-#' \code{new('GDS', ...)}
+#' @section Objects from the Class: Objects of this class are returned by
+#' \code{\link{getGEO}}; they are not normally constructed directly.
 #' @author Sean Davis
 #' @seealso \code{\link{GEOData-class}}
 #' @keywords classes
@@ -89,8 +124,8 @@ NULL
 #' Meta,GEOData-method Table,GEOData-method dataTable,GEOData-method
 #' show,GEOData-method
 #' @docType class
-#' @section Objects from the Class: Objects can be created by calls of the form
-#' \code{new('GEOData', ...)}.
+#' @section Objects from the Class: Objects of this class are returned by
+#' \code{\link{getGEO}}; they are not normally constructed directly.
 #' @author Sean Davis
 #' @seealso \code{\link{GDS-class}}, \code{\link{GPL-class}},
 #' \code{\link{GSM-class}}, \code{\link{GEODataTable-class}},
@@ -113,8 +148,8 @@ NULL
 #' Table,GEODataTable-method dataTable,GEODataTable-method
 #' show,GEODataTable-method
 #' @docType class
-#' @section Objects from the Class: Objects can be created by calls of the form
-#' \code{new('GEODataTable', ...)}.
+#' @section Objects from the Class: Objects of this class are returned by
+#' \code{\link{getGEO}}; they are not normally constructed directly.
 #' @author Sean Davis
 #' @keywords classes
 NULL
@@ -130,8 +165,8 @@ NULL
 #' @aliases GPL GPL,GDS-method
 #' @name GPL-class
 #' @docType class
-#' @section Objects from the Class: Objects can be created by calls of the form
-#' \code{new('GPL', ...)}.
+#' @section Objects from the Class: Objects of this class are returned by
+#' \code{\link{getGEO}}; they are not normally constructed directly.
 #' @author Sean Davis
 #' @seealso \code{\link{GEOData-class}}
 #' @keywords classes
@@ -149,8 +184,8 @@ NULL
 #' @name GSE-class
 #' @aliases GSE-class GPLList,GSE-method GSMList,GSE-method Meta,GSE-method
 #' @docType class
-#' @section Objects from the Class: Objects can be created by calls of the form
-#' \code{new('GSE', ...)}.
+#' @section Objects from the Class: Objects of this class are returned by
+#' \code{\link{getGEO}}; they are not normally constructed directly.
 #' @author Sean Davis
 #' @seealso \code{\link{GPL-class}},\code{\link{GSM-class}}
 #' @keywords classes
@@ -167,8 +202,8 @@ NULL
 #' 
 #' @name GSM-class
 #' @docType class
-#' @section Objects from the Class: Objects can be created by calls of the form
-#' \code{new('GSM', ...)}.
+#' @section Objects from the Class: Objects of this class are returned by
+#' \code{\link{getGEO}}; they are not normally constructed directly.
 #' @author Sean Davis
 #' @seealso \code{\link{GEOData-class}}
 #' @keywords classes

--- a/R/getGEO.R
+++ b/R/getGEO.R
@@ -109,6 +109,7 @@
 #' @seealso \code{\link{getGEOfile}}
 #' @keywords IO
 #' @examples
+#' \dontrun{
 #' 
 #' gds <- getGEO('GDS10')
 #' gds
@@ -118,6 +119,7 @@
 #' 
 #' gse[[1]]
 #' 
+#' }
 #' @export
 getGEO <- function(GEO = NULL, filename = NULL, destdir = tempdir(), GSElimits = NULL,
     GSEMatrix = TRUE, AnnotGPL = FALSE, getGPL = TRUE, parseCharacteristics = TRUE,

--- a/R/getGEOSuppFiles.R
+++ b/R/getGEOSuppFiles.R
@@ -94,6 +94,7 @@ getGEOSuppFileURL <- function(GEO) {
 #' @author Sean Davis <sdavis2@@mail.nih.gov>
 #' @keywords IO database
 #' @examples
+#' \dontrun{
 #' 
 #' a <- getGEOSuppFiles('GSM1137', fetch_files = FALSE)
 #' a
@@ -102,6 +103,7 @@ getGEOSuppFileURL <- function(GEO) {
 #' a <- getGEOSuppFiles('GSE161228', fetch_files = FALSE)
 #' a
 #' 
+#' }
 #' @export
 getGEOSuppFiles <- function(
     GEO,
@@ -177,8 +179,10 @@ getGEOSuppFiles <- function(
 #' @param GSE character(1) the GSE accession
 #' 
 #' @examples
+#' \dontrun{
 #' getGEOSeriesFileListing('GSE288770')
 #' 
+#' }
 #' @export
 getGEOSeriesFileListing <- function(GSE) {
   url = getGEOSuppFileURL(GSE)

--- a/R/getGSEDataTables.R
+++ b/R/getGSEDataTables.R
@@ -20,11 +20,13 @@
 #' 
 #' @keywords IO
 #' @examples
+#' \dontrun{
 #' 
 #' dfl = getGSEDataTables('GSE3494')
 #' lapply(dfl,head)
 #'
 #' 
+#' }
 #' @export 
 getGSEDataTables <- function(GSE) {
     url = sprintf("https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?targ=self&form=xml&view=full&acc=%s",

--- a/R/rnaseq.R
+++ b/R/rnaseq.R
@@ -126,8 +126,10 @@ urlExtractRNASeqQuantGenomeInfo <- function(url) {
 #' @return A character vector with the genome build and species information
 #'
 #' @examples
+#' \dontrun{
 #' getRNASeqQuantGenomeInfo("GSE164073")
 #'
+#' }
 #' @export
 getRNASeqQuantGenomeInfo <- function(gse) {
   links <- getGSEDownloadPageURLs(gse)
@@ -288,9 +290,11 @@ hasRNASeqQuantifications <- function(accession) {
 #'
 #'
 #' @examples
+#' \dontrun{
 #' se <- getRNASeqData("GSE164073")
 #' se
 #'
+#' }
 #' @export
 getRNASeqData <- function(accession) {
   quantifications <- getRNASeqQuantResults(accession)

--- a/man/GDS-class.Rd
+++ b/man/GDS-class.Rd
@@ -8,8 +8,8 @@
 A class describing a GEO GDS entity
 }
 \section{Objects from the Class}{
- Objects can be created by calls of the form
-\code{new('GDS', ...)}
+ Objects of this class are returned by
+\code{\link{getGEO}}; they are not normally constructed directly.
 }
 
 \seealso{

--- a/man/GEOData-accessors.Rd
+++ b/man/GEOData-accessors.Rd
@@ -9,12 +9,53 @@
 \alias{GSMList}
 \alias{Meta}
 \alias{Table}
-\title{Generic functions for GEOquery}
+\title{Accessors for GEOquery objects}
+\arguments{
+\item{object}{A GEOquery S4 object (\code{GSE}, \code{GSM}, \code{GPL},
+\code{GDS}, or \code{GEODataTable}).}
+}
+\value{
+\code{Meta()} a list; \code{Accession()} a character string;
+\code{Table()} and \code{Columns()} data.frames; \code{dataTable()} a
+\code{GEODataTable}; \code{GSMList()} and \code{GPLList()} named lists.
+}
 \description{
-The main documentation is in the Class documentation
+Accessor generics for the S4 objects returned by \code{\link{getGEO}} when
+parsing SOFT-format records (\code{GSE}, \code{GSM}, \code{GPL}, \code{GDS}).
+Use these rather than reaching into slots directly.
+}
+\details{
+\describe{
+  \item{\code{Meta(object)}}{The record metadata as a named list (title,
+    submission dates, sample/platform attributes, and so on).}
+  \item{\code{Accession(object)}}{The GEO accession (the
+    \code{geo_accession} metadata field).}
+  \item{\code{Table(object)}}{The data table as a \code{data.frame} -- for
+    example the measurement table of a \code{GSM} or the probe annotation of
+    a \code{GPL}.}
+  \item{\code{Columns(object)}}{A \code{data.frame} describing the columns of
+    \code{Table(object)}.}
+  \item{\code{dataTable(object)}}{The underlying \code{GEODataTable} object,
+    which holds both \code{Table()} and \code{Columns()}.}
+  \item{\code{GSMList(object)}}{For a \code{GSE}, the list of its \code{GSM}
+    sample objects.}
+  \item{\code{GPLList(object)}}{For a \code{GSE}, the list of its \code{GPL}
+    platform objects.}
+}
+}
+\examples{
+\dontrun{
+  gsm <- getGEO("GSM11805")
+  Meta(gsm)$title
+  head(Table(gsm))
+  Columns(gsm)
+
+  gse <- getGEO("GSE781", GSEMatrix = FALSE)
+  names(GSMList(gse))
+}
 }
 \seealso{
-\code{\link{GEOData-class}}
+\code{\link{GEOData-class}}, \code{\link{getGEO}}
 }
 \author{
 Sean Davis

--- a/man/GEOData-class.Rd
+++ b/man/GEOData-class.Rd
@@ -14,8 +14,8 @@
 A virtual class for holding GEO samples, platforms, and datasets
 }
 \section{Objects from the Class}{
- Objects can be created by calls of the form
-\code{new('GEOData', ...)}.
+ Objects of this class are returned by
+\code{\link{getGEO}}; they are not normally constructed directly.
 }
 
 \seealso{

--- a/man/GEODataTable-class.Rd
+++ b/man/GEODataTable-class.Rd
@@ -15,8 +15,8 @@ Contains the column descriptions and data for the datatable part of a GEO
 object
 }
 \section{Objects from the Class}{
- Objects can be created by calls of the form
-\code{new('GEODataTable', ...)}.
+ Objects of this class are returned by
+\code{\link{getGEO}}; they are not normally constructed directly.
 }
 
 \author{

--- a/man/GPL-class.Rd
+++ b/man/GPL-class.Rd
@@ -10,8 +10,8 @@
 Contains a full GEO Platform entity
 }
 \section{Objects from the Class}{
- Objects can be created by calls of the form
-\code{new('GPL', ...)}.
+ Objects of this class are returned by
+\code{\link{getGEO}}; they are not normally constructed directly.
 }
 
 \seealso{

--- a/man/GSE-class.Rd
+++ b/man/GSE-class.Rd
@@ -11,8 +11,8 @@
 Contains a GEO Series entity
 }
 \section{Objects from the Class}{
- Objects can be created by calls of the form
-\code{new('GSE', ...)}.
+ Objects of this class are returned by
+\code{\link{getGEO}}; they are not normally constructed directly.
 }
 
 \seealso{

--- a/man/GSM-class.Rd
+++ b/man/GSM-class.Rd
@@ -8,8 +8,8 @@
 A class containing a GEO Sample entity
 }
 \section{Objects from the Class}{
- Objects can be created by calls of the form
-\code{new('GSM', ...)}.
+ Objects of this class are returned by
+\code{\link{getGEO}}; they are not normally constructed directly.
 }
 
 \seealso{

--- a/man/getGEO.Rd
+++ b/man/getGEO.Rd
@@ -147,6 +147,7 @@ gse <- getGEO('GSE10')
 gse[[1]]
 
 }
+}
 
 \seealso{
 \code{\link{getGEOfile}}

--- a/man/getGEO.Rd
+++ b/man/getGEO.Rd
@@ -136,6 +136,7 @@ that coffee may be involved when parsing....
 }
 
 \examples{
+\dontrun{
 
 gds <- getGEO('GDS10')
 gds
@@ -146,6 +147,7 @@ gse <- getGEO('GSE10')
 gse[[1]]
 
 }
+
 \seealso{
 \code{\link{getGEOfile}}
 }

--- a/man/getGEOSeriesFileListing.Rd
+++ b/man/getGEOSeriesFileListing.Rd
@@ -27,4 +27,5 @@ as a data.frame.
 getGEOSeriesFileListing('GSE288770')
 
 }
+}
 

--- a/man/getGEOSeriesFileListing.Rd
+++ b/man/getGEOSeriesFileListing.Rd
@@ -23,6 +23,8 @@ This function reads that file listing file and returns the results
 as a data.frame.
 }
 \examples{
+\dontrun{
 getGEOSeriesFileListing('GSE288770')
 
 }
+

--- a/man/getGEOSuppFiles.Rd
+++ b/man/getGEOSuppFiles.Rd
@@ -64,6 +64,7 @@ a <- getGEOSuppFiles('GSE161228', fetch_files = FALSE)
 a
 
 }
+}
 
 \author{
 Sean Davis \href{mailto:sdavis2@mail.nih.gov}{sdavis2@mail.nih.gov}

--- a/man/getGEOSuppFiles.Rd
+++ b/man/getGEOSuppFiles.Rd
@@ -54,6 +54,7 @@ computer.
 Again, just a note that the files are simply downloaded.
 }
 \examples{
+\dontrun{
 
 a <- getGEOSuppFiles('GSM1137', fetch_files = FALSE)
 a
@@ -63,6 +64,7 @@ a <- getGEOSuppFiles('GSE161228', fetch_files = FALSE)
 a
 
 }
+
 \author{
 Sean Davis \href{mailto:sdavis2@mail.nih.gov}{sdavis2@mail.nih.gov}
 }

--- a/man/getGSEDataTables.Rd
+++ b/man/getGSEDataTables.Rd
@@ -23,12 +23,14 @@ tables.  This function simply downloads the ``header'' information from the
 GSE record and parses out the data tables into R data.frames.
 }
 \examples{
+\dontrun{
 
 dfl = getGSEDataTables('GSE3494')
 lapply(dfl,head)
 
 
 }
+
 \seealso{
 \code{\link{getGEO}}
 }

--- a/man/getGSEDataTables.Rd
+++ b/man/getGSEDataTables.Rd
@@ -30,6 +30,7 @@ lapply(dfl,head)
 
 
 }
+}
 
 \seealso{
 \code{\link{getGEO}}

--- a/man/getRNASeqData.Rd
+++ b/man/getRNASeqData.Rd
@@ -38,7 +38,9 @@ See the
 for more details.
 }
 \examples{
+\dontrun{
 se <- getRNASeqData("GSE164073")
 se
 
 }
+

--- a/man/getRNASeqData.Rd
+++ b/man/getRNASeqData.Rd
@@ -43,4 +43,5 @@ se <- getRNASeqData("GSE164073")
 se
 
 }
+}
 

--- a/man/getRNASeqQuantGenomeInfo.Rd
+++ b/man/getRNASeqQuantGenomeInfo.Rd
@@ -21,4 +21,5 @@ for a GEO RNA-seq quantification.
 getRNASeqQuantGenomeInfo("GSE164073")
 
 }
+}
 

--- a/man/getRNASeqQuantGenomeInfo.Rd
+++ b/man/getRNASeqQuantGenomeInfo.Rd
@@ -17,6 +17,8 @@ This function extracts the genome build and species information
 for a GEO RNA-seq quantification.
 }
 \examples{
+\dontrun{
 getRNASeqQuantGenomeInfo("GSE164073")
 
 }
+


### PR DESCRIPTION
Closes #103.

The `GEOData-accessors` page said only *"The main documentation is in the Class documentation"*, and every class page told users to construct objects with `new('X', ...)` — which is never how they're obtained.

- **Accessors documented**: `Meta`, `Accession`, `Table`, `Columns`, `dataTable`, `GSMList`, `GPLList` now have a description per generic, arguments, return values, a `\seealso{getGEO}`, and runnable examples.
- **Class pages corrected**: the misleading "Objects can be created by calls of the form `new('X', ...)`" boilerplate is replaced with "returned by `getGEO()`; not normally constructed directly" across all six class pages.

Edited both the roxygen source and the generated `man/` pages by hand (roxygen2 wasn't installable in this environment — `R CMD check`/BiocCheck validate the Rd). Bumps to 2.77.19.