### PR TITLE
fix: getGEOSingleCell(combine=TRUE) aligns samples on shared features (#190)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - `geoSingleCellManifest()` and `getGEOSingleCell()` now handle the common case where a Series ships only a `GSE..._RAW.tar` at the series level and the per-sample files live in each sample's own GSM suppl directory (e.g. GSE132771). When the series level has no loadable single-cell units, the manifest falls back to enumerating the Series' samples (via `getGEO()`) and inventorying each GSM suppl directory. Both functions also accept a GSM accession directly (`getGEOSingleCell("GSM3891612")`), and `geoSingleCellManifest()` gains a `samples` argument to restrict to specific GSMs without enumerating the whole Series. Unit files are downloaded by URL, so the readers work whether the data lives at the series or sample level (#190).
 
+## Bug Fixes
+
+- `getGEOSingleCell(combine = TRUE)` no longer fails with a cryptic `cbind` error (`'mcols' ... do not match`) when a Series' samples come from different platforms or genome references — common in single-cell studies (e.g. GSE132771 mixes mouse and human). Samples are now restricted to their shared features before binding; if they share no features (so a single combined object is impossible) a clear, actionable error is raised instead (#190).
+
 # GEOquery 2.81.21 (2026-06-13)
 
 ## Breaking changes

--- a/R/getGEOSuppFiles.R
+++ b/R/getGEOSuppFiles.R
@@ -27,7 +27,11 @@ getDirListing <- function(url) {
 
 #' Get GEO supplemental file URL for a given GEO accession
 #'
-#' @param GEO
+#' @param GEO A GEO accession, e.g. a Series ("GSE..."), Sample ("GSM..."), or
+#'   Platform ("GPL...") id. The accession type determines which FTP `suppl/`
+#'   directory URL is returned.
+#' @return A character(1) URL of the accession's supplementary-file directory on
+#'   the NCBI GEO FTP site.
 #'
 #' @examples
 #' # an example of a GEO supplemental file URL

--- a/R/singlecell.R
+++ b/R/singlecell.R
@@ -368,6 +368,34 @@ readGEOSingleCell <- function(x, format = NULL) {
     }, character(1))
 }
 
+# cbind a list of SingleCellExperiments into one. Samples in a study often come
+# from different references/platforms (e.g. GSE132771 mixes mouse and human) or
+# CellRanger versions, so their feature sets -- and thus rowData -- differ and a
+# naive cbind() errors ("'mcols' ... do not match"). Restrict every object to
+# the features common to all, in one consistent order, so the rows align before
+# binding. Error clearly when there is no shared feature space to combine on.
+.combine_sce <- function(results) {
+    common <- Reduce(intersect, lapply(results, rownames))
+    if (length(common) == 0) {
+        stop(
+            "Cannot combine: the samples share no common features (rownames). ",
+            "They likely come from different platforms or genome references ",
+            "(e.g. a study mixing organisms). Combine compatible subsets via ",
+            "`samples=`, or use `combine = FALSE` and merge as appropriate.",
+            call. = FALSE
+        )
+    }
+    dropped <- sum(vapply(results, function(x) nrow(x) - length(common), integer(1)))
+    if (dropped > 0) {
+        message(sprintf(
+            "Combining on %d feature(s) shared by all %d samples (dropped %d non-shared feature row(s) across samples).",
+            length(common), length(results), dropped
+        ))
+    }
+    aligned <- lapply(results, function(x) x[common, ])
+    do.call(SummarizedExperiment::cbind, aligned)
+}
+
 #' Download and read the single-cell data of a GEO Series or Sample
 #'
 #' High-level, best-effort convenience wrapper: inventories the GSE (or GSM)
@@ -391,8 +419,11 @@ readGEOSingleCell <- function(x, format = NULL) {
 #' @param samples Optional character vector of GSM ids to restrict to. Ignored
 #'   when \code{GEO} is itself a GSM.
 #' @param format Optional format(s) to restrict to ("10x_mtx", "10x_h5", "h5ad").
-#' @param combine Logical; if TRUE attempt to \code{cbind} the per-sample
-#'   objects into one (requires matching features). Default FALSE returns a list.
+#' @param combine Logical; if TRUE, \code{cbind} the per-sample objects into one,
+#'   restricting to the features (rownames) common to all samples so they align
+#'   even when samples come from different references or platforms. Errors if the
+#'   samples share no common features (e.g. a study mixing organisms). Default
+#'   FALSE returns a named list.
 #' @param destdir Download destination directory.
 #' @return A named list of \code{SingleCellExperiment} (one per sample), or a
 #'   single combined object if \code{combine = TRUE}.
@@ -431,7 +462,7 @@ getGEOSingleCell <- function(GEO, samples = NULL, format = NULL, combine = FALSE
         results[[u$sample]] <- readGEOSingleCell(local, format = u$format)
     }
     if (combine && length(results) > 1) {
-        return(do.call(SummarizedExperiment::cbind, results))
+        return(.combine_sce(results))
     }
     results
 }

--- a/man/getGEOSingleCell.Rd
+++ b/man/getGEOSingleCell.Rd
@@ -21,8 +21,11 @@ when \code{GEO} is itself a GSM.}
 
 \item{format}{Optional format(s) to restrict to ("10x_mtx", "10x_h5", "h5ad").}
 
-\item{combine}{Logical; if TRUE attempt to \code{cbind} the per-sample
-objects into one (requires matching features). Default FALSE returns a list.}
+\item{combine}{Logical; if TRUE, \code{cbind} the per-sample objects into one,
+restricting to the features (rownames) common to all samples so they align
+even when samples come from different references or platforms. Errors if the
+samples share no common features (e.g. a study mixing organisms). Default
+FALSE returns a named list.}
 
 \item{destdir}{Download destination directory.}
 }

--- a/man/getGEOSuppFileURL.Rd
+++ b/man/getGEOSuppFileURL.Rd
@@ -6,6 +6,15 @@
 \usage{
 getGEOSuppFileURL(GEO)
 }
+\arguments{
+\item{GEO}{A GEO accession, e.g. a Series ("GSE..."), Sample ("GSM..."), or
+Platform ("GPL...") id. The accession type determines which FTP \verb{suppl/}
+directory URL is returned.}
+}
+\value{
+A character(1) URL of the accession's supplementary-file directory on
+the NCBI GEO FTP site.
+}
 \description{
 Get GEO supplemental file URL for a given GEO accession
 }

--- a/tests/testthat/test_singlecell.R
+++ b/tests/testthat/test_singlecell.R
@@ -106,6 +106,49 @@ test_that(".sc_manifest_from_gsms returns an empty manifest for no input", {
     expect_true(all(c("fname", "sample", "format", "role", "url") %in% colnames(m)))
 })
 
+# A minimal SingleCellExperiment with the given feature (row) names.
+.fake_sce <- function(genes, cells) {
+    m <- matrix(
+        seq_len(length(genes) * length(cells)),
+        nrow = length(genes),
+        dimnames = list(genes, cells)
+    )
+    SingleCellExperiment::SingleCellExperiment(assays = list(counts = m))
+}
+
+test_that(".combine_sce binds samples that share all features (#190)", {
+    skip_if_not_installed("SingleCellExperiment")
+    a <- .fake_sce(c("g1", "g2", "g3"), c("c1", "c2"))
+    b <- .fake_sce(c("g1", "g2", "g3"), c("c3", "c4", "c5"))
+    out <- GEOquery:::.combine_sce(list(A = a, B = b))
+    expect_equal(nrow(out), 3L)
+    expect_equal(ncol(out), 5L)
+    expect_equal(rownames(out), c("g1", "g2", "g3"))
+})
+
+test_that(".combine_sce restricts to common features when they differ (#190)", {
+    skip_if_not_installed("SingleCellExperiment")
+    a <- .fake_sce(c("g1", "g2", "g3"), c("c1", "c2"))
+    b <- .fake_sce(c("g2", "g3", "g4"), c("c3", "c4"))
+    expect_message(
+        out <- GEOquery:::.combine_sce(list(A = a, B = b)),
+        "Combining on 2 feature"
+    )
+    expect_equal(nrow(out), 2L)
+    expect_equal(ncol(out), 4L)
+    expect_setequal(rownames(out), c("g2", "g3"))
+})
+
+test_that(".combine_sce errors when samples share no features (#190)", {
+    skip_if_not_installed("SingleCellExperiment")
+    a <- .fake_sce(c("g1", "g2"), c("c1"))
+    b <- .fake_sce(c("g3", "g4"), c("c2"))
+    expect_error(
+        GEOquery:::.combine_sce(list(A = a, B = b)),
+        "no common features"
+    )
+})
+
 # ---- Integration tests (live network; GSE132771) --------------------------
 # GSE132771 ships only a GSE..._RAW.tar at the series level; its per-sample 10x
 # triplets live in each GSM suppl directory. Exercises the GSM-level fallback
@@ -157,4 +200,30 @@ test_that("getGEOSingleCell(GSE, samples=) reads selected samples (#190)", {
         samples = c("GSM3891614", "GSM3891615"), destdir = tempfile("sc_"))
     expect_named(res, c("GSM3891614", "GSM3891615"))
     expect_s4_class(res[[1]], "SingleCellExperiment")
+})
+
+test_that("getGEOSingleCell(combine=TRUE) binds same-platform samples (#190)", {
+    skip_if_no_integration()
+    skip_if_not_installed("TENxIO")
+    skip_if_not_installed("SingleCellExperiment")
+    # GSM3891614/615 are both mouse (GPL21103) -> identical features.
+    out <- getGEOSingleCell("GSE132771",
+        samples = c("GSM3891614", "GSM3891615"), destdir = tempfile("sc_"),
+        combine = TRUE)
+    expect_s4_class(out, "SingleCellExperiment")
+    expect_gt(ncol(out), 0L)
+})
+
+test_that("getGEOSingleCell(combine=TRUE) errors on incompatible platforms (#190)", {
+    skip_if_no_integration()
+    skip_if_not_installed("TENxIO")
+    skip_if_not_installed("SingleCellExperiment")
+    # GSM3891612 is mouse (GPL21103), GSM3891620 is human (GPL24676): no shared
+    # features, so a combined object is impossible -- expect a clear error.
+    expect_error(
+        getGEOSingleCell("GSE132771",
+            samples = c("GSM3891612", "GSM3891620"), destdir = tempfile("sc_"),
+            combine = TRUE),
+        "no common features"
+    )
 })


### PR DESCRIPTION
## Problem

`getGEOSingleCell(combine = TRUE)` failed on **GSE132771** (and any multi-platform single-cell Series). The function did a blind `do.call(SummarizedExperiment::cbind, results)`, which errors with a cryptic message when per-sample objects have different feature sets:

```
column(s) 'ID' in 'mcols' are duplicated and the data do not match
```

GSE132771 spans two platforms — mouse (GPL21103, 27998 features) and human (GPL24676, 33694 features) — so the per-sample `SingleCellExperiment`s cannot be `cbind`-ed as-is.

## Fix

New internal `.combine_sce()`:
- Restricts every sample to the features (`rownames`) **common to all**, in one consistent order, before binding — so samples align even across different references/CellRanger versions.
- Raises a **clear, actionable error** when samples share no features (a single combined object is genuinely impossible, e.g. mixing organisms), instead of the cryptic `cbind` failure.

## Verification

- Same-platform combine still works: `samples = c("GSM3891614","GSM3891615")` → `SingleCellExperiment` 27998 × 4031.
- Cross-platform combine now errors clearly pointing to `samples=` / `combine = FALSE`.
- Tests: offline unit tests for identical / overlapping / disjoint feature sets, plus live integration tests for both combine paths. Full single-cell suite: **68/68** pass (offline **49/49**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)