### PR TITLE
fix: getGEOSingleCell(combine=TRUE) handles heterogeneous rowData (#190)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 ## Bug Fixes
 
-- `getGEOSingleCell(combine = TRUE)` no longer fails with a cryptic `cbind` error (`'mcols' ... do not match`) when a Series' samples come from different platforms or genome references — common in single-cell studies (e.g. GSE132771 mixes mouse and human). Samples are now restricted to their shared features before binding; if they share no features (so a single combined object is impossible) a clear, actionable error is raised instead (#190).
+- `getGEOSingleCell(combine = TRUE)` no longer fails with a cryptic `cbind` error (`'mcols' ... do not match` or `subscript contains invalid names`) when a Series' samples have heterogeneous feature annotation — common in single-cell studies (e.g. GSE132771 mixes mouse and human, and mixes 10x CellRanger v2 `genes.tsv` with v3 `features.tsv`, giving different rowData columns). Samples are now restricted to their shared features and given one canonical rowData (the shared columns) before binding; if they share no features (so a single combined object is impossible) a clear, actionable error is raised instead (#190).
 
 # GEOquery 2.81.21 (2026-06-13)
 

--- a/R/singlecell.R
+++ b/R/singlecell.R
@@ -370,10 +370,14 @@ readGEOSingleCell <- function(x, format = NULL) {
 
 # cbind a list of SingleCellExperiments into one. Samples in a study often come
 # from different references/platforms (e.g. GSE132771 mixes mouse and human) or
-# CellRanger versions, so their feature sets -- and thus rowData -- differ and a
-# naive cbind() errors ("'mcols' ... do not match"). Restrict every object to
-# the features common to all, in one consistent order, so the rows align before
-# binding. Error clearly when there is no shared feature space to combine on.
+# CellRanger versions, so a naive cbind() fails two ways: the feature sets
+# (rownames) differ, and even when they match the rowData *columns* differ (10x
+# v2 genes.tsv -> ID,Symbol vs v3 features.tsv -> ID,Symbol,Type), which trips
+# cbind's "rowData must be identical" check ("subscript contains invalid names").
+# Align every object to the features common to all, in one consistent order, and
+# give them one canonical rowData (the first sample's, restricted to the columns
+# shared by all) so the rows match exactly before binding. Error clearly when
+# there is no shared feature space to combine on.
 .combine_sce <- function(results) {
     common <- Reduce(intersect, lapply(results, rownames))
     if (length(common) == 0) {
@@ -393,6 +397,17 @@ readGEOSingleCell <- function(x, format = NULL) {
         ))
     }
     aligned <- lapply(results, function(x) x[common, ])
+    # Impose one canonical rowData so heterogeneous per-sample feature annotation
+    # (differing columns or values for the same feature) cannot block the cbind.
+    common_cols <- Reduce(
+        intersect,
+        lapply(aligned, function(x) colnames(SummarizedExperiment::rowData(x)))
+    )
+    canon <- SummarizedExperiment::rowData(aligned[[1]])[, common_cols, drop = FALSE]
+    aligned <- lapply(aligned, function(x) {
+        SummarizedExperiment::rowData(x) <- canon
+        x
+    })
     do.call(SummarizedExperiment::cbind, aligned)
 }
 

--- a/tests/testthat/test_singlecell.R
+++ b/tests/testthat/test_singlecell.R
@@ -106,14 +106,24 @@ test_that(".sc_manifest_from_gsms returns an empty manifest for no input", {
     expect_true(all(c("fname", "sample", "format", "role", "url") %in% colnames(m)))
 })
 
-# A minimal SingleCellExperiment with the given feature (row) names.
-.fake_sce <- function(genes, cells) {
+# A minimal SingleCellExperiment with the given feature (row) names. `rowdata`
+# names the rowData columns to attach (each filled from the gene ids), mimicking
+# 10x v2 (genes.tsv -> ID,Symbol) vs v3 (features.tsv -> ID,Symbol,Type).
+.fake_sce <- function(genes, cells, rowdata = NULL) {
     m <- matrix(
         seq_len(length(genes) * length(cells)),
         nrow = length(genes),
         dimnames = list(genes, cells)
     )
-    SingleCellExperiment::SingleCellExperiment(assays = list(counts = m))
+    sce <- SingleCellExperiment::SingleCellExperiment(assays = list(counts = m))
+    if (!is.null(rowdata)) {
+        rd <- S4Vectors::DataFrame(
+            lapply(stats::setNames(rowdata, rowdata), function(col) genes),
+            row.names = genes
+        )
+        SummarizedExperiment::rowData(sce) <- rd
+    }
+    sce
 }
 
 test_that(".combine_sce binds samples that share all features (#190)", {
@@ -146,6 +156,23 @@ test_that(".combine_sce errors when samples share no features (#190)", {
     expect_error(
         GEOquery:::.combine_sce(list(A = a, B = b)),
         "no common features"
+    )
+})
+
+test_that(".combine_sce binds samples with differing rowData columns (#190)", {
+    skip_if_not_installed("SingleCellExperiment")
+    # Same features, but 10x v2 (ID,Symbol) vs v3 (ID,Symbol,Type) rowData -- a
+    # naive cbind() fails with "subscript contains invalid names". The combine
+    # reduces to the shared rowData columns and binds.
+    genes <- c("g1", "g2", "g3")
+    a <- .fake_sce(genes, c("c1", "c2"), rowdata = c("ID", "Symbol"))
+    b <- .fake_sce(genes, c("c3", "c4"), rowdata = c("ID", "Symbol", "Type"))
+    out <- GEOquery:::.combine_sce(list(A = a, B = b))
+    expect_equal(nrow(out), 3L)
+    expect_equal(ncol(out), 4L)
+    expect_equal(
+        colnames(SummarizedExperiment::rowData(out)),
+        c("ID", "Symbol")
     )
 })
 


### PR DESCRIPTION
## Problem

Follow-up to #201. `getGEOSingleCell(combine = TRUE)` still failed on **same-organism** samples whose 10x feature annotation differs:

```
Error: ! subscript contains invalid names
```

GSE132771's 16 human samples (GSM3891620–GSM3891635) all share the same 33694 features, but mix CellRanger **v2** `genes.tsv` (rowData columns `ID, Symbol`) with **v3** `features.tsv` (`ID, Symbol, Type`). `cbind` on `SingleCellExperiment`/`SummarizedExperiment` requires *identical* rowData across objects, so the differing columns abort the bind deep inside the mcols reconciliation. (Two samples happened to slip through; the full mix did not.)

## Fix

After aligning to the common features, `.combine_sce()` now imposes **one canonical rowData** — the first sample's, restricted to the rowData columns shared by all — on every object before binding. This makes the rows match exactly regardless of per-sample annotation differences (extra columns, or differing `Symbol` values for the same feature).

## Verification

- GSE132771's 16 human samples now combine: `SingleCellExperiment` **33694 × 83704** (rowData reduced to shared `ID, Symbol`).
- Same-platform and cross-platform (#201) behavior unchanged; cross-organism still errors clearly.
- New offline test for differing-rowData samples; single-cell suite **71/71** pass (offline **52/52**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)