### PR TITLE
test: verify h5ad reader on a modern dataset (GSE312831) + OmicIDX parquet notes (#190)

### DIFF
--- a/dev/single-cell-example-datasets.md
+++ b/dev/single-cell-example-datasets.md
@@ -28,7 +28,9 @@ Maintainer reference only — this directory is excluded from the package build
 | **GSE132771** | `10x_mtx` | TENxIO | per-sample | `_RAW.tar` **and** per-GSM suppl | **2** — GPL21103 (mouse, 8), GPL24676 (human, 16) | GSE→GSM fallback; `by="platform"` grouping; cross-platform combine error; mixed CellRanger v2 `genes.tsv` / v3 `features.tsv` → differing rowData |
 | **GSE145926** | `10x_h5` | TENxIO | per-sample | `_RAW.tar` **and** per-GSM suppl (`*_filtered_feature_bc_matrix.h5`) | 1 (12) | clean per-sample 10x HDF5. **Reader verified** (GSM4339769 → SCE 33539×6249) |
 | **GSE122960** | `10x_h5` | TENxIO | per-sample | `_RAW.tar` (`*_filtered_gene_bc_matrices_h5.h5`) | 1 (17) | second 10x HDF5 example; alt filename |
-| **GSE161228** | `h5ad` | anndataR | **whole-study** | series-level loose (`GSE161228_*.h5ad.gz`, no GSM) | 1 | already-combined single files; `sample = NA`; combine is N/A. **Classification + gunzip verified, reader fails**: files are anndata<0.8.0, which anndataR cannot import |
+| **GSE312831** | `h5ad` | anndataR | **whole-study** | series-level (`GSE312831_*.h5ad`, no GSM) | 1 | small (~2 MB) modern anndata. **Reader verified** (→ SCE 23507×6) |
+| **GSE328481** | `h5ad` | anndataR | **per-sample** | per-GSM suppl (`GSM9684206_*.h5ad`, one per sample) | 1 | per-sample h5ad layout (files ~1 GB each, so large to read) |
+| **GSE161228** | `h5ad` | anndataR | **whole-study** | series-level loose (`GSE161228_*.h5ad.gz`, no GSM) | 1 | already-combined single files; `sample = NA`. **Classification + gunzip verified, reader fails**: files are anndata<0.8.0, which anndataR cannot import (a 2020 study) |
 | **GSE154567** | `10x_h5` + `rds` | TENxIO (h5) | per-sample | `_RAW.tar` (9 `.h5` + 9 `.rds`) | 1 (9) | mixed formats in one study; format selection/preference |
 | **GSE150728** | `rds` (Seurat) | — | whole-study | series-level + `_RAW.tar` | 1 (13) | manifest classification of out-of-scope format |
 | **GSE131907** | `rds` (Seurat) | — | whole-study | series-level (2 `.rds`) | 1 (58) | manifest classification of out-of-scope format |
@@ -51,18 +53,37 @@ Maintainer reference only — this directory is excluded from the package build
 
 ## Reader-pathway coverage (verified live 2026-06-14)
 
+All three import pathways verified end-to-end:
+
 - `10x_mtx` (TENxIO) — **verified** (GSE132771 GSM3891612 → SCE 27998×4245).
 - `10x_h5` (TENxIO) — **verified** (GSE145926 GSM4339769 → SCE 33539×6249).
-- `h5ad` (anndataR) — classification + transparent `.gz` decompression
-  verified, but **no readable example yet**: GSE161228's files are
-  anndata&lt;0.8.0 (anndataR errors). A modern h5ad study is still needed to
-  exercise the reader end-to-end.
+- `h5ad` (anndataR) — **verified** (GSE312831 → SCE 23507×6). Older h5ad
+  (anndata&lt;0.8.0, e.g. GSE161228) cannot be read; prefer recent submissions.
+
+## Finding more examples (OmicIDX GEO parquet)
+
+GEO metadata, including each accession's supplemental file list, is published as
+DuckDB-queryable parquet — far easier than scraping FTP:
+
+- `https://data-omicidx.cancerdatasci.org/geo/parquet/geo_series.parquet`
+- `https://data-omicidx.cancerdatasci.org/geo/parquet/geo_samples.parquet`
+
+`supplemental_files` is a `varchar[]` of FTP URLs. To find recent readable h5ad:
+
+```sql
+INSTALL httpfs; LOAD httpfs;
+SELECT accession, submission_date,
+       list_filter(supplemental_files, x -> x ILIKE '%h5ad%') AS h5ad
+FROM read_parquet('https://data-omicidx.cancerdatasci.org/geo/parquet/geo_series.parquet')
+WHERE array_to_string(supplemental_files, ';') ILIKE '%.h5ad%'
+ORDER BY submission_date DESC LIMIT 25;
+```
+
+`geo_series` carries `sample_id[]` (its GSMs), `sample_organism[]`, `platform_id[]`;
+`geo_samples` is keyed by GSM. The parquet has no file sizes — `curl -I` the URL.
 
 ## Gaps still wanted
 
-- A **modern, readable `.h5ad`** study (anndata ≥ 0.8.0) — to exercise the
-  anndataR reader end-to-end, ideally **per-sample** (`GSM*_….h5ad`) to also
-  test h5ad grouping.
 - A **loom** study — manifest classification only (reader out of scope).
 - A confirmed **multi-platform h5/h5ad** study — to test `by="platform"` beyond
-  the 10x_mtx case.
+  the 10x_mtx case (all h5/h5ad examples so far are single-platform).

--- a/tests/testthat/test_singlecell.R
+++ b/tests/testthat/test_singlecell.R
@@ -322,3 +322,17 @@ test_that("whole-study .h5ad.gz files are one unit each (#190)", {
     expect_equal(nrow(u), 3L)
     expect_true(all(u$loadable))
 })
+
+test_that("getGEOSingleCell reads a (modern) h5ad into a SingleCellExperiment (#190)", {
+    skip_if_no_integration()
+    skip_if_not_installed("anndataR")
+    skip_if_not_installed("SingleCellExperiment")
+    # GSE312831 is a small (~2 MB) whole-study .h5ad written with a recent
+    # anndata, so anndataR can import it. Exercises the h5ad reader pathway
+    # end-to-end (found via the OmicIDX GEO parquet; see dev/ notes).
+    res <- getGEOSingleCell("GSE312831", destdir = tempfile("ad_"))
+    expect_type(res, "list")
+    expect_length(res, 1L)
+    expect_s4_class(res[[1]], "SingleCellExperiment")
+    expect_gt(nrow(res[[1]]), 0L)
+})


### PR DESCRIPTION
Closes the h5ad reader-coverage gap from #203. All three single-cell import pathways are now verified end-to-end.

## How

Used the **OmicIDX GEO parquet** (DuckDB-queryable metadata, incl. each accession's `supplemental_files` list) to find recent, readable `.h5ad` studies — much easier than scraping FTP:

```sql
SELECT accession, submission_date,
       list_filter(supplemental_files, x -> x ILIKE '%h5ad%') AS h5ad
FROM read_parquet('https://data-omicidx.cancerdatasci.org/geo/parquet/geo_series.parquet')
WHERE array_to_string(supplemental_files, ';') ILIKE '%.h5ad%'
ORDER BY submission_date DESC;
```

## What's added

- **Integration test** reading **GSE312831** (small ~2 MB whole-study `.h5ad`, recent anndata) → `SingleCellExperiment` 23507×6. Verifies the anndataR pathway end-to-end.
- **dev/ table** updated: GSE312831 (whole-study h5ad, reader verified), GSE328481 (per-sample h5ad), and a section documenting the OmicIDX parquet discovery method.

## Why GSE161228 wasn't enough

It's a 2020 study (anndata<0.8.0) which anndataR refuses; GSE312831 (2026) reads fine — confirming the limitation is the file's anndata version, not our code. GSE161228 stays as the whole-study-`.h5ad.gz` *classification* example.

Reader coverage now: `10x_mtx` ✓ (GSE132771), `10x_h5` ✓ (GSE145926), `h5ad` ✓ (GSE312831). Offline suite 58/58; single-cell live suite 94 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)