### PR TITLE
test: use a genuine single-cell h5ad (GSE310450) for the reader test (#190)

### DIFF
--- a/dev/single-cell-example-datasets.md
+++ b/dev/single-cell-example-datasets.md
@@ -28,8 +28,9 @@ Maintainer reference only — this directory is excluded from the package build
 | **GSE132771** | `10x_mtx` | TENxIO | per-sample | `_RAW.tar` **and** per-GSM suppl | **2** — GPL21103 (mouse, 8), GPL24676 (human, 16) | GSE→GSM fallback; `by="platform"` grouping; cross-platform combine error; mixed CellRanger v2 `genes.tsv` / v3 `features.tsv` → differing rowData |
 | **GSE145926** | `10x_h5` | TENxIO | per-sample | `_RAW.tar` **and** per-GSM suppl (`*_filtered_feature_bc_matrix.h5`) | 1 (12) | clean per-sample 10x HDF5. **Reader verified** (GSM4339769 → SCE 33539×6249) |
 | **GSE122960** | `10x_h5` | TENxIO | per-sample | `_RAW.tar` (`*_filtered_gene_bc_matrices_h5.h5`) | 1 (17) | second 10x HDF5 example; alt filename |
-| **GSE312831** | `h5ad` | anndataR | **whole-study** | series-level (`GSE312831_*.h5ad`, no GSM) | 1 | small (~2 MB) modern anndata. **Reader verified** (→ SCE 23507×6) |
+| **GSE310450** | `h5ad` | anndataR | **whole-study** | series-level (`GSE310450_WTS_LACZ.h5ad`, no GSM) | 1 | ~62 MB modern anndata, genuinely single-cell. **Reader verified** (→ SCE 14021×8603) |
 | **GSE328481** | `h5ad` | anndataR | **per-sample** | per-GSM suppl (`GSM9684206_*.h5ad`, one per sample) | 1 | per-sample h5ad layout (files ~1 GB each, so large to read) |
+| GSE312831 | `h5ad` | anndataR | whole-study | series-level (`GSE312831_*.h5ad`) | 1 | tiny (~2 MB) but **bulk** (`bulkseq`, 6 columns) — readable, not single-cell; not used as the reader example |
 | **GSE161228** | `h5ad` | anndataR | **whole-study** | series-level loose (`GSE161228_*.h5ad.gz`, no GSM) | 1 | already-combined single files; `sample = NA`. **Classification + gunzip verified, reader fails**: files are anndata<0.8.0, which anndataR cannot import (a 2020 study) |
 | **GSE154567** | `10x_h5` + `rds` | TENxIO (h5) | per-sample | `_RAW.tar` (9 `.h5` + 9 `.rds`) | 1 (9) | mixed formats in one study; format selection/preference |
 | **GSE150728** | `rds` (Seurat) | — | whole-study | series-level + `_RAW.tar` | 1 (13) | manifest classification of out-of-scope format |
@@ -57,8 +58,9 @@ All three import pathways verified end-to-end:
 
 - `10x_mtx` (TENxIO) — **verified** (GSE132771 GSM3891612 → SCE 27998×4245).
 - `10x_h5` (TENxIO) — **verified** (GSE145926 GSM4339769 → SCE 33539×6249).
-- `h5ad` (anndataR) — **verified** (GSE312831 → SCE 23507×6). Older h5ad
-  (anndata&lt;0.8.0, e.g. GSE161228) cannot be read; prefer recent submissions.
+- `h5ad` (anndataR) — **verified** (GSE310450 → SCE 14021×8603, real
+  single-cell). Older h5ad (anndata&lt;0.8.0, e.g. GSE161228) cannot be read;
+  prefer recent submissions.
 
 ## Finding more examples (OmicIDX GEO parquet)
 

--- a/tests/testthat/test_singlecell.R
+++ b/tests/testthat/test_singlecell.R
@@ -327,12 +327,14 @@ test_that("getGEOSingleCell reads a (modern) h5ad into a SingleCellExperiment (#
     skip_if_no_integration()
     skip_if_not_installed("anndataR")
     skip_if_not_installed("SingleCellExperiment")
-    # GSE312831 is a small (~2 MB) whole-study .h5ad written with a recent
-    # anndata, so anndataR can import it. Exercises the h5ad reader pathway
-    # end-to-end (found via the OmicIDX GEO parquet; see dev/ notes).
-    res <- getGEOSingleCell("GSE312831", destdir = tempfile("ad_"))
+    # GSE310450 is a whole-study .h5ad (~62 MB) written with a recent anndata
+    # holding real single-cell data (~8600 cells), so anndataR imports it and it
+    # is genuinely single-cell. Exercises the h5ad reader pathway end-to-end
+    # (found via the OmicIDX GEO parquet; see dev/ notes).
+    res <- getGEOSingleCell("GSE310450", destdir = tempfile("ad_"))
     expect_type(res, "list")
     expect_length(res, 1L)
     expect_s4_class(res[[1]], "SingleCellExperiment")
     expect_gt(nrow(res[[1]]), 0L)
+    expect_gt(ncol(res[[1]]), 1000L)
 })


### PR DESCRIPTION
Follow-up to #204. The h5ad reader example there (GSE312831) is **bulk** RNA-seq — only 6 columns despite reading cleanly — so it didn't really exercise single-cell-scale data.

Swaps it for **GSE310450**, a ~62 MB modern whole-study `.h5ad` with **~8,600 cells** (→ `SingleCellExperiment` 14021×8603), and asserts `ncol > 1000` so the test confirms genuine single-cell data. GSE312831 is kept in the dev table as a noted bulk/readable counter-example.

Found via the same OmicIDX parquet query, filtering out `bulk`/`rnaseq` filenames and checking sizes.

Offline suite 58/58; GSE310450 read verified live (14021×8603).

🤖 Generated with [Claude Code](https://claude.com/claude-code)