### PR TITLE
ci: set NOT_CRAN=true so the integration workflow actually runs live tests

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -22,6 +22,10 @@ jobs:
       image: bioconductor/bioconductor_docker:devel
     env:
       GEOQUERY_INTEGRATION: "true"
+      # The suite runs under `R CMD check` (--as-cran). skip_if_no_integration()
+      # calls skip_on_cran() first, which skips unless NOT_CRAN=true -- so
+      # without this every live test silently skips, defeating the workflow.
+      NOT_CRAN: "true"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

The `integration.yaml` workflow is meant to run the live-network single-cell tests against real GEO. It sets `GEOQUERY_INTEGRATION=true`, but the suite runs under `R CMD check` (`--as-cran`), and `skip_if_no_integration()` calls `skip_on_cran()` **first** — which skips unless `NOT_CRAN=true`. That variable was never set, so **every live test silently skipped**: the latest run was `FAIL 0 | SKIP 48 | PASS 132`, identical to an offline run. The workflow was passing green while exercising **zero** real GEO data.

(Found while triggering the workflow on `devel` after the single-cell work — run [27512037647](https://github.com/seandavi/GEOquery/actions/runs/27512037647).)

## Fix

Add `NOT_CRAN: "true"` to the workflow env so `skip_on_cran()` is a no-op and the `GEOQUERY_INTEGRATION` gate lets the ~12 live tests run.

**PR CI is unaffected**: it sets neither `NOT_CRAN` nor `GEOQUERY_INTEGRATION`, so the integration tests still skip there via the `GEOQUERY_INTEGRATION` check (they remain non-blocking for PRs).

After merge I'll re-trigger the workflow to confirm the live tests actually execute (expect the SKIP count to drop by ~12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)